### PR TITLE
First revision pass at Harry's script in English

### DIFF
--- a/scripts/EN/Harry
+++ b/scripts/EN/Harry
@@ -1333,7 +1333,7 @@ CleanScreen(); // 0x1524: 00000064
 LoadBackground(0x3); // 0x1528: 00001069
 LoadEffect(0x3, 0x2, 0x0); // 0x152e: 0000306d
 OP_0x65(); // 0x1538: 00000065
-ShowText((1013)"Cheryl's eyes are closed. She is dreaming. I know that I should be awake. But what is this uneasy feeling? I feel as if my body is not totally my own. It's like someone, some strange being that is not me, is controlling me...like I am floating."); // 0x153c: 0000100c
+ShowText((1013)"Cheryl's eyes are closed. She is dreaming. I know that I should be awake. But what is this uneasy feeling? I feel as if my body is not totally my own. It's like someone, some strange being that is not me, is controlling me... like I am floating."); // 0x153c: 0000100c
 HandleInput(); // 0x1542: 00000010
 ShowText((1014)"My eyelids are heavy. As the steering wheel leaves my hand it creates the illusion of setting the course on its own. Freezing cold... Uneasiness... Almost like being ready to fall asleep, I am just barely conscious, and now at my limit to maintain even that."); // 0x1546: 0000100c
 HandleInput(); // 0x154c: 00000010
@@ -1342,7 +1342,7 @@ CleanScreen(); // 0x1558: 00000064
 LoadBackground(0x6); // 0x155c: 00001069
 OP_0x65(); // 0x1562: 00000065
 WaitTime(0x1e); // 0x1566: 0000101f
-ShowText((1015)"¥"Ah......¥""); // 0x156c: 0000100c
+ShowText((1015)"¥"Ah...¥""); // 0x156c: 0000100c
 HandleInput(); // 0x1572: 00000010
 CleanScreen(); // 0x1576: 00000064
 LoadBackground(0x7); // 0x157a: 00001069
@@ -1364,7 +1364,7 @@ ShowText((1016)"The silence pierces my ears. As the wind blew, it was accompanie
 HandleInput(); // 0x15cc: 00000010
 ShowText((1017)"I don't seem to be hurt. That much is clear to me because I don't feel any pain in my body. No, perhaps I've suffered an injury that doesn't cause any pain?"); // 0x15d0: 0000100c
 HandleInput(); // 0x15d6: 00000010
-ShowText((1018)"I...slowly try opening my heavy eyelids."); // 0x15da: 0000100c
+ShowText((1018)"I... slowly try opening my heavy eyelids."); // 0x15da: 0000100c
 HandleInput(); // 0x15e0: 00000010
 Jump(L_0x15ea); // 0x15e4: 00001001
 L_0x15ea:
@@ -1395,7 +1395,7 @@ LoadSecondEffect(0x5, 0x1, 0x0, 0x1); // 0x1672: 0000406e
 PlayMusic(0x65, 0x1); // 0x167e: 0000206c
 ShowText((1022)"¥"Silent Hill.¥" This town, which should just be a resort area, appears to have become just like a ghost town for some reason, or maybe it was waiting for us to arrive, or perhaps the town just nestled up to us..."); // 0x1686: 0000100c
 HandleInput(); // 0x168c: 00000010
-ShowText((1023)"So now I am alone. Cheryl is not here. While I was sleeping, no, while I was knocked out Cheryl opened the passenger door and stepped out ¥"alone¥" into this tourist spot that is ruled by an unsettling silence."); // 0x1690: 0000100c
+ShowText((1023)"So now I am alone. Cheryl is not here. While I was sleeping, no, while I was knocked out Cheryl opened the passenger door and stepped out alone into this tourist spot that is ruled by an unsettling silence."); // 0x1690: 0000100c
 HandleInput(); // 0x1696: 00000010
 ShowText((1024)"And then she left me to head somewhere..."); // 0x169a: 0000100c
 HandleInput(); // 0x16a0: 00000010
@@ -1435,7 +1435,7 @@ ShowText((1026)"I begin to run. Only the sounds of my footsteps echo in the surr
 HandleInput(); // 0x175a: 00000010
 LoadSecondEffect(0x18, 0x1, 0x1); // 0x175e: 0000306e
 PlaySecondSoundFx(0x9); // 0x1768: 00001073
-ShowText((1027)"(Ta ta ta ta...) (Onomatopoeia for footsteps) I suddenly get the feeling that I heard footsteps other than my own, so I stop moving right away to check it out."); // 0x176e: 0000100c
+ShowText((1027)"(Tap, tap, tap, tap...) I suddenly get the feeling that I heard footsteps other than my own, so I stop moving right away to check it out."); // 0x176e: 0000100c
 HandleInput(); // 0x1774: 00000010
 ShowText((1028)"Through the thick fog I can see a figure that is about the size of a child. ¥"Cheryl?¥" Without a thought I cry out. The figure doesn't move at all."); // 0x1778: 0000100c
 HandleInput(); // 0x177e: 00000010
@@ -1490,13 +1490,13 @@ CleanScreen(); // 0x1882: 00000064
 LoadBackground(0xd); // 0x1886: 00001069
 OP_0x65(); // 0x188c: 00000065
 PlayMusic(0x66, 0x1); // 0x1890: 0000206c
-ShowText((1034)"I stood ready. ¥"What the... What are they...¥" With beast-like rage, they have closed in to right where I am."); // 0x1898: 0000100c
+ShowText((1034)"I stood ready. ¥"What the...? What are they...?¥" With beast-like rage, they have closed in to right where I am."); // 0x1898: 0000100c
 HandleInput(); // 0x189e: 00000010
 CleanScreen(); // 0x18a2: 00000064
 LoadBackground(0xc); // 0x18a6: 00001069
 LoadEffect(0x19, 0x1, 0x0); // 0x18ac: 0000306d
 OP_0x65(); // 0x18b6: 00000065
-ShowText((1035)"¥"Ah...¥" And then my vitality is sucked away by these strangely shaped monsters until I finally lose consciousness............"); // 0x18ba: 0000100c
+ShowText((1035)"¥"Ah...¥" And then my vitality is sucked away by these strangely shaped monsters until I finally lose consciousness..."); // 0x18ba: 0000100c
 HandleInput(); // 0x18c0: 00000010
 PlaySecondSoundFx(0x2b); // 0x18c4: 00001073
 LoadSecondEffect(0x0, 0x0, 0x0); // 0x18ca: 0000306e
@@ -1527,7 +1527,7 @@ CleanScreen(); // 0x1950: 00000064
 LoadBackground(0xd); // 0x1954: 00001069
 OP_0x65(); // 0x195a: 00000065
 PlayMusic(0x66, 0x1); // 0x195e: 0000206c
-ShowText((1039)"I've got to get away. But I can't go back the way I came...because that eerie presence is back there..."); // 0x1966: 0000100c
+ShowText((1039)"I've got to get away. But I can't go back the way I came... because that eerie presence is back there..."); // 0x1966: 0000100c
 HandleInput(); // 0x196c: 00000010
 ShowText((1040)"So I move further in. I can only move gradually through the narrowing pitch-black alley by feeling around with my hands."); // 0x1970: 0000100c
 HandleInput(); // 0x1976: 00000010
@@ -1535,13 +1535,13 @@ ShowText((1041)"But I only end up reaching a dead end. Metal fences surround the
 HandleInput(); // 0x1980: 00000010
 ShowText((1042)"They are coming from behind..."); // 0x1984: 0000100c
 HandleInput(); // 0x198a: 00000010
-ShowText((1034)"I stood ready. ¥"What the... What are they...¥" With beast-like rage, they have closed in to right where I am."); // 0x198e: 0000100c
+ShowText((1034)"I stood ready. ¥"What the...? What are they...?¥" With beast-like rage, they have closed in to right where I am."); // 0x198e: 0000100c
 HandleInput(); // 0x1994: 00000010
 CleanScreen(); // 0x1998: 00000064
 LoadBackground(0xc); // 0x199c: 00001069
 LoadEffect(0x19, 0x1, 0x0); // 0x19a2: 0000306d
 OP_0x65(); // 0x19ac: 00000065
-ShowText((1035)"¥"Ah...¥" And then my vitality is sucked away by these strangely shaped monsters until I finally lose consciousness............"); // 0x19b0: 0000100c
+ShowText((1035)"¥"Ah...¥" And then my vitality is sucked away by these strangely shaped monsters until I finally lose consciousness..."); // 0x19b0: 0000100c
 HandleInput(); // 0x19b6: 00000010
 PlaySecondSoundFx(0x2b); // 0x19ba: 00001073
 LoadSecondEffect(0x0, 0x0, 0x0); // 0x19c0: 0000306e
@@ -1585,12 +1585,12 @@ ShowText((1047)"¥"It looks like you have come around.¥" ¥"Who are you?¥" I t
 HandleInput(); // 0x1a94: 00000010
 ShowText((1048)"¥"I'm Cybil. Cybil Bennett. I'm here because all communication with this town suddenly went dead and so I came to investigate.¥""); // 0x1a98: 0000100c
 HandleInput(); // 0x1a9e: 00000010
-ShowText((1049)"¥"I'm...Harry Mason. I brought my daughter to this town for some sightseeing, but on the way there was an accident and I lost consciousness... Oh, yeah, Cybil...You haven't seen a little girl in this town have you?¥""); // 0x1aa2: 0000100c
+ShowText((1049)"¥"I'm... Harry Mason. I brought my daughter to this town for some sightseeing, but on the way there was an accident and I lost consciousness... Oh, yeah, Cybil... You haven't seen a little girl in this town, have you?¥""); // 0x1aa2: 0000100c
 HandleInput(); // 0x1aa8: 00000010
 LoadSecondEffect(0x5f, 0x1, 0x1); // 0x1aac: 0000306e
 ShowText((1050)"¥"A little girl... No, I haven't seen her...¥" ¥"When I came to after the accident my daughter was nowhere to be seen. The passenger door was open and she was gone."); // 0x1ab6: 0000100c
 HandleInput(); // 0x1abc: 00000010
-ShowText((1051)"Cheryl...uh, sorry, my daughter's name is Cheryl... She is a timid person, so it is hard to imagine that she headed out into this weird town alone. Plus I was there in the driver's seat... And since she gave me no warning it just doesn't make sense."); // 0x1ac0: 0000100c
+ShowText((1051)"Cheryl... Uh, sorry, my daughter's name is Cheryl... She is a timid person, so it is hard to imagine that she headed out into this weird town alone. Plus I was there in the driver's seat... And since she gave me no warning it just doesn't make sense."); // 0x1ac0: 0000100c
 HandleInput(); // 0x1ac6: 00000010
 ShowText((1052)"Are you familiar with this area? There is no sign of anyone, and what is going on with the snow at this time of year... Just what in the world has happened in this town?¥" I said all of this while breathing deeply."); // 0x1aca: 0000100c
 HandleInput(); // 0x1ad0: 00000010
@@ -1599,11 +1599,11 @@ ShowText((1053)"¥"I'm afraid I don't know either. I still haven't seen anyone o
 HandleInput(); // 0x1ae4: 00000010
 ShowText((1054)"¥"You also had an accident, right? I thought it was a good idea to head to the police station in this town alone on my motorcycle, but... I guess I was going a little too fast."); // 0x1ae8: 0000100c
 HandleInput(); // 0x1aee: 00000010
-ShowText((1055)"A girl suddenly jumped out into the road...I am pretty sure it was a girl...I almost hit her. I cut the handlebars hard in order to avoid her... After that I can barely remember anything......"); // 0x1af2: 0000100c
+ShowText((1055)"A girl suddenly jumped out into the road... I am pretty sure it was a girl... I almost hit her. I cut the handlebars hard in order to avoid her... After that I can barely remember anything..."); // 0x1af2: 0000100c
 HandleInput(); // 0x1af8: 00000010
 ShowText((1056)"When I came to I was lying in the street in front of this cafe. So naturally I came in here to get out of the snow. And then I found you sleeping there...¥""); // 0x1afc: 0000100c
 HandleInput(); // 0x1b02: 00000010
-ShowText((1057)"¥"I...was having some kind of a terrible dream. As for if I made it here on my own, I don't remember at all... Just what in the world has happened in this town... What is going on with everything?¥""); // 0x1b06: 0000100c
+ShowText((1057)"¥"I... was having some kind of a terrible dream. As for if I made it here on my own, I don't remember at all... Just what in the world has happened in this town...? What is going on with everything?¥""); // 0x1b06: 0000100c
 HandleInput(); // 0x1b0c: 00000010
 ShowText((1058)"¥"Well, the situation is definitely strange. I will head back to Brahms for reinforcements, and then return here. How about you?¥" Cybil stood and fixed her collar with resolute fortitude."); // 0x1b10: 0000100c
 HandleInput(); // 0x1b16: 00000010
@@ -1624,7 +1624,7 @@ CleanScreen(); // 0x1b64: 00000064
 LoadBackground(0x18); // 0x1b68: 00001069
 OP_0x65(); // 0x1b6e: 00000065
 PlayMusic(0x67, 0x1); // 0x1b72: 0000206c
-Choice((20)"I take the gun into my hand.", (21)"A ) Thanks...I hope I don't have to use it...", (22)"B ) Thank you, but...I'm no good with guns."); // 0x1b7a: 00003011
+Choice((20)"I take the gun into my hand.", (21)"A ) Thanks... I hope I don't have to use it...", (22)"B ) Thank you, but... I'm no good with guns."); // 0x1b7a: 00003011
 Branch4(0x57f, L_0x1b9e); // 0x1b84: 00001004
 CleanScreen(); // 0x1b8a: 00000064
 LoadBackground(0x0); // 0x1b8e: 00001069
@@ -1650,7 +1650,7 @@ LoadSecondEffect(0xd, 0x1, 0x0); // 0x1be4: 0000306e
 LoadSecondEffect(0x5f, 0x2, 0x1); // 0x1bee: 0000306e
 ShowText((1061)"Having never handled a handgun before I am surprised by how heavy it is."); // 0x1bf8: 0000100c
 HandleInput(); // 0x1bfe: 00000010
-ShowText((1062)"¥"But you...will you be alright?¥" ¥"I'm not like the average girls around here. I have undergone proper training.¥""); // 0x1c02: 0000100c
+ShowText((1062)"¥"But you... will you be alright?¥" ¥"I'm not like the average girls around here. I have undergone proper training.¥""); // 0x1c02: 0000100c
 HandleInput(); // 0x1c08: 00000010
 LoadSecondEffect(0x0, 0x0, 0x1); // 0x1c0c: 0000306e
 CleanScreen(); // 0x1c16: 00000064
@@ -1783,7 +1783,7 @@ TitleAndSubtitle(0x14, 0x208); // 0x1eda: 00002062
 LoadSecondEffect(0x1a, 0x1, 0x0, 0x1); // 0x1ee2: 0000406e
 PlayMusic(0x66, 0x1); // 0x1eee: 0000206c
 Area(0x14); // 0x1ef6: 00001026
-Choice((50)"I limit my aim...", (51)"A ) Its vulnerable spot is...its body.", (52)"B ) Aiming at the wing will bring it down."); // 0x1efc: 00003011
+Choice((50)"I limit my aim...", (51)"A ) Its vulnerable spot is... its body.", (52)"B ) Aiming at the wing will bring it down."); // 0x1efc: 00003011
 Branch4(0x5a9, L_0x1f12); // 0x1f06: 00001004
 Jump(L_0x1f26); // 0x1f0c: 00001001
 L_0x1f12:
@@ -1803,7 +1803,7 @@ ShowText((1078)"It swings its large arm-like wing down at me and using that ¥"w
 HandleInput(); // 0x1f58: 00000010
 ShowText((1079)"This is my chance. The target is its body... Mumbling, I tell myself that."); // 0x1f5c: 0000100c
 HandleInput(); // 0x1f62: 00000010
-ShowText((4503)"However...I can't fix my aim very well. My hands are shaking."); // 0x1f66: 0000100c
+ShowText((4503)"However... I can't fix my aim very well. My hands are shaking."); // 0x1f66: 0000100c
 HandleInput(); // 0x1f6c: 00000010
 OP_0x29(); // 0x1f70: 00000029
 PlaySecondSoundFx(0xf); // 0x1f74: 00001073
@@ -1857,7 +1857,7 @@ OP_0x65(); // 0x2080: 00000065
 PlayMusic(0x67, 0x1); // 0x2084: 0000206c
 LoadSecondEffect(0xd, 0x1, 0x0); // 0x208c: 0000306e
 LoadSecondEffect(0x5f, 0x2, 0x1); // 0x2096: 0000306e
-ShowText((1084)"¥"Thank you, but...I'm no good with guns. I haven't even touched one. I can't handle it.¥""); // 0x20a0: 0000100c
+ShowText((1084)"¥"Thank you, but... I'm no good with guns. I haven't even touched one. I can't handle it.¥""); // 0x20a0: 0000100c
 HandleInput(); // 0x20a6: 00000010
 LoadSecondEffect(0x0, 0x0, 0x1); // 0x20aa: 0000306e
 CleanScreen(); // 0x20b4: 00000064
@@ -1882,7 +1882,7 @@ LoadSecondEffect(0xd, 0x1, 0x0); // 0x2110: 0000306e
 LoadSecondEffect(0x5f, 0x1, 0x1); // 0x211a: 0000306e
 ShowText((1088)"¥"He...Hey! You need to watch it!!¥" ¥"I'm sorry, I was just doing what you said and it just...¥" ¥"No it's not ¥"and it just...¥" Just a few centimeters over and you would have been a murderer!¥""); // 0x2124: 0000100c
 HandleInput(); // 0x212a: 00000010
-ShowText((1089)"I lost even more self confidence. ¥"Well, it's all right. Please use it carefully. Well then...I'm going.¥" The sound of the door closing reverberated woefully inside the cafe."); // 0x212e: 0000100c
+ShowText((1089)"I lost even more self-confidence. ¥"Well, it's all right. Please use it carefully. Well then... I'm going.¥" The sound of the door closing reverberated woefully inside the cafe."); // 0x212e: 0000100c
 HandleInput(); // 0x2134: 00000010
 LoadSecondEffect(0x0, 0x0, 0x1); // 0x2138: 0000306e
 CleanScreen(); // 0x2142: 00000064
@@ -1918,7 +1918,7 @@ LoadBackground(0x16); // 0x2202: 00001069
 OP_0x65(); // 0x2208: 00000065
 ShowText((1092)"My one shot hits the wing, blasting a large hole in it. The creature loses altitude as it falls to the floor."); // 0x220c: 0000100c
 HandleInput(); // 0x2212: 00000010
-ShowText((1093)"I can't afford to waste bullets. I crush it with the with the thick sole of my shoe many times. As its strange cries die out, a dark red stain spreads out on the floor."); // 0x2216: 0000100c
+ShowText((1093)"I can't afford to waste bullets. I crush it with the thick sole of my shoe many times. As its strange cries die out, a dark red stain spreads out on the floor."); // 0x2216: 0000100c
 HandleInput(); // 0x221c: 00000010
 LoadSecondEffect(0x0, 0x0, 0x0); // 0x2220: 0000306e
 CleanScreen(); // 0x222a: 00000064
@@ -1940,7 +1940,7 @@ ShowText((1096)"That's it. I must set my aim. Its body. When it spreads its wing
 HandleInput(); // 0x2284: 00000010
 ShowText((1097)"It swings its large arm-like wing down at me and using that ¥"weapon¥" it just misses my neck."); // 0x2288: 0000100c
 HandleInput(); // 0x228e: 00000010
-ShowText((1098)"This is my chance. The target is its body... Mumbling, I tell myself that. However...I can't fix my aim very well. My hands are shaking."); // 0x2292: 0000100c
+ShowText((1098)"This is my chance. The target is its body... Mumbling, I tell myself that. However... I can't fix my aim very well. My hands are shaking."); // 0x2292: 0000100c
 HandleInput(); // 0x2298: 00000010
 OP_0x29(); // 0x229c: 00000029
 PlaySecondSoundFx(0xf); // 0x22a0: 00001073
@@ -1990,7 +1990,7 @@ LoadBackground(0x16); // 0x23b6: 00001069
 OP_0x65(); // 0x23bc: 00000065
 ShowText((1107)"My one shot hits the wing, blasting a hole in it. The creature loses altitude as it falls to the floor."); // 0x23c0: 0000100c
 HandleInput(); // 0x23c6: 00000010
-ShowText((1108)"I can't afford to waste bullets. I crush it with the with the thick sole of my shoe many times. As its strange cries die out, a dark red stain spreads out on the floor."); // 0x23ca: 0000100c
+ShowText((1108)"I can't afford to waste bullets. I crush it with the thick sole of my shoe many times. As its strange cries die out, a dark red stain spreads out on the floor."); // 0x23ca: 0000100c
 HandleInput(); // 0x23d0: 00000010
 LoadSecondEffect(0x0, 0x0, 0x0); // 0x23d4: 0000306e
 CleanScreen(); // 0x23de: 00000064
@@ -2070,7 +2070,7 @@ CleanScreen(); // 0x2568: 00000064
 LoadBackground(0x0); // 0x256c: 00001069
 OP_0x65(); // 0x2572: 00000065
 PlayMusic(0x68, 0x1); // 0x2576: 0000206c
-ShowText((1121)"Along Levin street I slip through the backdoor of a house that had a doghouse and then head for the school. The surroundings gradually fill with darkness and only the flashlight on my chest illuminates this strange street."); // 0x257e: 0000100c
+ShowText((1121)"Along Levin Street I slip through the backdoor of a house that had a doghouse and then head for the school. The surroundings gradually fill with darkness and only the flashlight on my chest illuminates this strange street."); // 0x257e: 0000100c
 HandleInput(); // 0x2584: 00000010
 OP_0x2c(0x3, 0x1); // 0x2588: 0000202c
 Jump(L_0x2596); // 0x2590: 00001001
@@ -2141,7 +2141,7 @@ CleanScreen(); // 0x26d8: 00000064
 LoadBackground(0x0); // 0x26dc: 00001069
 OP_0x65(); // 0x26e2: 00000065
 PlaySecondSoundFx(0xc); // 0x26e6: 00001073
-ShowText((1134)"At the same time I closed the door thought I heard someone scream......... Maybe it was just my imagination?"); // 0x26ec: 0000100c
+ShowText((1134)"At the same time I closed the door thought I heard someone scream... Maybe it was just my imagination?"); // 0x26ec: 0000100c
 HandleInput(); // 0x26f2: 00000010
 Jump(L_0x26fc); // 0x26f6: 00001001
 L_0x26fc:
@@ -2192,7 +2192,7 @@ HandleInput(); // 0x27f6: 00000010
 ShowText((1141)"I ready the gun. I fix my aim on their heads and pull the trigger with my trembling index finger."); // 0x27fa: 0000100c
 HandleInput(); // 0x2800: 00000010
 PlaySecondSoundFx(0xf); // 0x2804: 00001073
-ShowText((1142)"I continue to shoot as each one of them appears. The smoke from the gun powder began to fill the air around me so I placed one hand over my mouth."); // 0x280a: 0000100c
+ShowText((1142)"I continue to shoot as each one of them appears. The smoke of the gunpowder began to fill the air around me so I placed one hand over my mouth."); // 0x280a: 0000100c
 HandleInput(); // 0x2810: 00000010
 LoadSecondEffect(0x11, 0x1, 0x2); // 0x2814: 0000306e
 WaitTime(0x78); // 0x281e: 0000101f
@@ -2214,7 +2214,7 @@ LoadBackground(0x2a); // 0x2876: 00001069
 OP_0x65(); // 0x287c: 00000065
 ShowText((1144)"I begin running. I can't just stand around. There is not a moment to lose. Cheryl is waiting for me. Wait a minute. Suddenly my vision became hazy or something and I rubbed my eyes."); // 0x2880: 0000100c
 HandleInput(); // 0x2886: 00000010
-ShowText((1145)"When I look back... I see that all the bodies of the monsters have unexpectedly vanished. ¥"What...¥" Was I hallucinating or something? .............................."); // 0x288a: 0000100c
+ShowText((1145)"When I look back... I see that all the bodies of the monsters have unexpectedly vanished. ¥"What...¥" Was I hallucinating or something?"); // 0x288a: 0000100c
 HandleInput(); // 0x2890: 00000010
 Jump(L_0x289a); // 0x2894: 00001001
 L_0x289a:
@@ -2328,7 +2328,7 @@ OP_0x29(); // 0x2adc: 00000029
 PlaySecondSoundFx(0xf); // 0x2ae0: 00001073
 LoadSecondEffect(0xf, 0x1, 0x2); // 0x2ae6: 0000306e
 LoadSecondEffect(0x0, 0x0, 0x2); // 0x2af0: 0000306e
-ShowText((1142)"I continue to shoot as each one of them appears. The smoke from the gun powder began to fill the air around me so I placed one hand over my mouth."); // 0x2afa: 0000100c
+ShowText((1142)"I continue to shoot as each one of them appears. The smoke of the gunpowder began to fill the air around me so I placed one hand over my mouth."); // 0x2afa: 0000100c
 HandleInput(); // 0x2b00: 00000010
 LoadSecondEffect(0x11, 0x1, 0x2); // 0x2b04: 0000306e
 WaitTime(0x78); // 0x2b0e: 0000101f
@@ -2408,7 +2408,7 @@ LoadBackground(0x3e); // 0x2c8a: 00001069
 OP_0x65(); // 0x2c90: 00000065
 OP_0x2c(0x3, 0x1); // 0x2c94: 0000202c
 PlaySoundFx(0x16); // 0x2c9c: 00001072
-ShowText((1179)"With slight hope I pickup the telephone receiver. Just as I had guessed... The depressing busy signal just repeats over and over."); // 0x2ca2: 0000100c
+ShowText((1179)"With slight hope I pick up the telephone receiver. Just as I had guessed... The depressing busy signal just repeats over and over."); // 0x2ca2: 0000100c
 HandleInput(); // 0x2ca8: 00000010
 OP_0x29(); // 0x2cac: 00000029
 PlaySecondSoundFx(0x18); // 0x2cb0: 00001073
@@ -2424,7 +2424,7 @@ OP_0x65(); // 0x2cde: 00000065
 ShowText((1181)"I begin to leave the room."); // 0x2ce2: 0000100c
 HandleInput(); // 0x2ce8: 00000010
 PlaySoundFx(0x17); // 0x2cec: 00001072
-ShowText((1182)"Jiriririri...Jiriririri..."); // 0x2cf2: 0000100c
+ShowText((1182)"Riiing... Riiing..."); // 0x2cf2: 0000100c
 HandleInput(); // 0x2cf8: 00000010
 ShowText((1183)"My heart rapidly contracts. The mechanical bell sound echoes throughout the room. I nervously approach the telephone, and once again pick up the receiver."); // 0x2cfc: 0000100c
 HandleInput(); // 0x2d02: 00000010
@@ -2535,7 +2535,7 @@ ShowText((1203)"I now know where it is I need to go."); // 0x2f06: 0000100c
 HandleInput(); // 0x2f0c: 00000010
 ShowText((1204)"As I journey there I walk firmly, stepping forward one step at a time. I descend a staircase from which uncomfortably warm air flows and find an elevator at its base that invites me to descend even further, as its doors slowly open."); // 0x2f10: 0000100c
 HandleInput(); // 0x2f16: 00000010
-ShowText((1205)"Once I enter it's doors close, and in the next moment, with a rusty clunk sound the elevator begins to descend at a high rate of speed. Just how far down is it going? All I can do is go with the flow."); // 0x2f1a: 0000100c
+ShowText((1205)"Once I enter, its doors close, and in the next moment, with a rusty clunk sound the elevator begins to descend at a high rate of speed. Just how far down is it going? All I can do is go with the flow."); // 0x2f1a: 0000100c
 HandleInput(); // 0x2f20: 00000010
 CleanScreen(); // 0x2f24: 00000064
 LoadBackground(0x40); // 0x2f28: 00001069
@@ -2551,7 +2551,7 @@ LoadEffect(0x0, 0x0, 0x0); // 0x2f5a: 0000306d
 OP_0x65(); // 0x2f64: 00000065
 PlayMusic(0x66); // 0x2f68: 0000106c
 LoadSecondEffect(0x1f, 0x1, 0x1); // 0x2f6e: 0000306e
-ShowText((1207)"In the center the fires of hell burned, and everything made it look like this room was meant for prayer. And then it...was there. It slowly moved around the enormous sconce from which flames and ash rose."); // 0x2f78: 0000100c
+ShowText((1207)"In the center the fires of hell burned, and everything made it look like this room was meant for prayer. And then it... was there. It slowly moved around the enormous sconce from which flames and ash rose."); // 0x2f78: 0000100c
 HandleInput(); // 0x2f7e: 00000010
 ShowText((1208)"The lizard looks to have suddenly mutated. Its outer shell is a mucous membrane type. It just stares at me, and with surprisingly comfortable speed, it looks for a chance to attack."); // 0x2f82: 0000100c
 HandleInput(); // 0x2f88: 00000010
@@ -2579,7 +2579,7 @@ WaitTime(0x3c); // 0x3000: 0000101f
 PlaySecondSoundFx(0xf); // 0x3006: 00001073
 LoadSecondEffect(0xf, 0x1, 0x2); // 0x300c: 0000306e
 LoadSecondEffect(0x0, 0x0, 0x2); // 0x3016: 0000306e
-ShowText((1209)"Smoke and powder emit from my handgun. I am certain that I hit it. However, those armor-like scales more than fulfilled their purpose."); // 0x3020: 0000100c
+ShowText((1209)"Smoke and gunpowder emit from my handgun. I am certain that I hit it. However, those armor-like scales more than fulfilled their purpose."); // 0x3020: 0000100c
 HandleInput(); // 0x3026: 00000010
 ShowText((1210)"This isn't effective at all. This is no good, I need to make my bullets hit somewhere softer."); // 0x302a: 0000100c
 HandleInput(); // 0x3030: 00000010
@@ -2646,7 +2646,7 @@ LoadEffect(0x1f, 0x2, 0x1, 0x2); // 0x3170: 0000406d
 OP_0x65(); // 0x317c: 00000065
 PlayMusic(0x66, 0x1); // 0x3180: 0000206c
 LoadSecondEffect(0x1f, 0x2, 0x1, 0x1); // 0x3188: 0000406e
-Choice((110)"Ok...", (111)"A ) Fire into its mouth.", (112)"B ) I'll stop its movement first. I fired at its legs."); // 0x3194: 00003011
+Choice((110)"Okay...", (111)"A ) Fire into its mouth.", (112)"B ) I'll stop its movement first. I fired at its legs."); // 0x3194: 00003011
 Branch4(0x608, L_0x31aa); // 0x319e: 00001004
 Jump(L_0x31be); // 0x31a4: 00001001
 L_0x31aa:
@@ -2672,7 +2672,7 @@ HandleInput(); // 0x321a: 00000010
 PlaySecondSoundFx(0xf); // 0x321e: 00001073
 LoadSecondEffect(0xf, 0x1, 0x2); // 0x3224: 0000306e
 LoadSecondEffect(0x0, 0x0, 0x2); // 0x322e: 0000306e
-ShowText((1219)"And then I lost consciousness........."); // 0x3238: 0000100c
+ShowText((1219)"And then I lost consciousness..."); // 0x3238: 0000100c
 HandleInput(); // 0x323e: 00000010
 OP_0x2c(0x2, 0x1); // 0x3242: 0000202c
 Jump(L_0x3250); // 0x324a: 00001001
@@ -2687,7 +2687,7 @@ LoadBackground(0x2d); // 0x327e: 00001069
 OP_0x65(); // 0x3284: 00000065
 ShowText((1220)"When I came to I found myself in the middle of a dark room. Where is this? I wondered to myself."); // 0x3288: 0000100c
 HandleInput(); // 0x328e: 00000010
-ShowText((1221)"The monster from before has vanished. I heavily stood up and then waited motionless for a bit until my eyes came into focus. Somehow...somehow this looks to be the boiler room. It is oddly quiet."); // 0x3292: 0000100c
+ShowText((1221)"The monster from before has vanished. I heavily stood up and then waited motionless for a bit until my eyes came into focus. Somehow... Somehow this looks to be the boiler room. It is oddly quiet."); // 0x3292: 0000100c
 HandleInput(); // 0x3298: 00000010
 ShowText((1222)"Maybe I was dreaming? My very exhausted body seems to have also recovered somehow. The low hum of the boilers strangely calms my nerves."); // 0x329c: 0000100c
 HandleInput(); // 0x32a2: 00000010
@@ -2700,7 +2700,7 @@ ShowText((1225)"The girl was just staring right at me. Once I noticed her and be
 HandleInput(); // 0x32ca: 00000010
 LoadSecondEffect(0x5b, 0x2, 0x1); // 0x32ce: 0000306e
 LoadSecondEffect(0x0, 0x0, 0x1); // 0x32d8: 0000306e
-ShowText((1226)"¥"What was that?¥" A strange feeling of relief"); // 0x32e2: 0000100c
+ShowText((1226)"¥"What was that?¥""); // 0x32e2: 0000100c
 HandleInput(); // 0x32e8: 00000010
 Jump(L_0x32f2); // 0x32ec: 00001001
 L_0x32f2:
@@ -2735,11 +2735,11 @@ PlayMusic(0x6f, 0x1); // 0x337c: 0000206c
 ShowText((4001)"Without knowing why, I dialed my home number, where no one should be. Maybe there is a chance that Cheryl has already returned home... With slight hope I..."); // 0x3384: 0000100c
 HandleInput(); // 0x338a: 00000010
 PlaySoundFx(0x1d); // 0x338e: 00001072
-ShowText((4002)"(Bururururu...Bururururu...) (Onomatopoeia for ringing telephone) The phone is ringing... The mechanical electrical sound repeats over and over. Then all of a sudden it stopped."); // 0x3394: 0000100c
+ShowText((4002)"(Riiing... Riiing...) The phone is ringing... The mechanical electrical sound repeats over and over. Then all of a sudden it stopped."); // 0x3394: 0000100c
 HandleInput(); // 0x339a: 00000010
 OP_0x28(0x0, 0x1d); // 0x339e: 00002028
 PlaySecondSoundFx(0x18); // 0x33a6: 00001073
-ShowText((4003)"(......Hello) The voice of a man I do not know escapes from the receiver. ¥"Hello...who is this...¥""); // 0x33ac: 0000100c
+ShowText((4003)"(...Hello?) The voice of a man I do not know escapes from the receiver. ¥"Hello...? Who is this...?¥""); // 0x33ac: 0000100c
 HandleInput(); // 0x33b2: 00000010
 ShowText((4004)"From the receiver I hear a gasp. (Ah...) Click..."); // 0x33b6: 0000100c
 HandleInput(); // 0x33bc: 00000010
@@ -2775,7 +2775,7 @@ HandleInput(); // 0x3454: 00000010
 PlaySecondSoundFx(0x19); // 0x3458: 00001073
 ShowText((4011)"The next page is all blurred..."); // 0x345e: 0000100c
 HandleInput(); // 0x3464: 00000010
-ShowText((4012)"¥"[......tis] ..de from from the above-mentioned White Claudia,...dr...has.... u....to perform exor... It is a viscous liquid, red....color, and is... adminis...remedy...illnesses for which the cause is not kn....¥""); // 0x3468: 0000100c
+ShowText((4012)"¥"[......tis] ..de from the above-mentioned White Claudia,...dr...has.... u....to perform exor... It is a viscous liquid, red....color, and is... adminis...remedy...illnesses for which the cause is not kn....¥""); // 0x3468: 0000100c
 HandleInput(); // 0x346e: 00000010
 SaveVariable(0x3, 0x2); // 0x3472: 00002037
 Jump(L_0x2eaa); // 0x347a: 00001001
@@ -2787,7 +2787,7 @@ LoadBackground(0x42); // 0x3492: 00001069
 LoadEffect(0x55, 0x2, 0x1); // 0x3498: 0000306d
 OP_0x65(); // 0x34a2: 00000065
 PlaySecondSoundFx(0x19); // 0x34a6: 00001073
-ShowText((4013)"¥"Depending on the region each have the characteristic of having individual doctrines. From ancient times the practice of offering a living sacrifice was the only way to avoid disaster."); // 0x34ac: 0000100c
+ShowText((4013)"¥"Depending on the region, each have the characteristic of having individual doctrines. From ancient times the practice of offering a living sacrifice was the only way to avoid disaster."); // 0x34ac: 0000100c
 HandleInput(); // 0x34b2: 00000010
 PlaySecondSoundFx(0x19); // 0x34b6: 00001073
 ShowText((4014)"Most believers are those who have chosen to renounce the world for the sake of their beliefs, while those believers who can not yet give up their material possessions need to deepen their knowledge of the sacred texts. However, some believers have a tendency to strictly hide the fact that they are believers from others."); // 0x34bc: 0000100c
@@ -2884,9 +2884,9 @@ ShowText((4036)"In the Teacher's Room..."); // 0x36ce: 0000100c
 HandleInput(); // 0x36d4: 00000010
 ShowText((4037)"The phone call I received. Cheryl's cries dance about in my memory."); // 0x36d8: 0000100c
 HandleInput(); // 0x36de: 00000010
-ShowText((4038)"That's right...I cannot let myself die here. Cheryl is...Cheryl is waiting somewhere for me to rescue her. She is still alive."); // 0x36e2: 0000100c
+ShowText((4038)"That's right... I cannot let myself die here. Cheryl is... Cheryl is waiting somewhere for me to rescue her. She is still alive."); // 0x36e2: 0000100c
 HandleInput(); // 0x36e8: 00000010
-ShowText((4039)"I raised my head. Its hard scales shined in the light from the hell fires. It must have a weak point. If I can just hit that."); // 0x36ec: 0000100c
+ShowText((4039)"I raised my head. Its hard scales shined in the light from the hell fires. It must have a weak point. If I can just hit that..."); // 0x36ec: 0000100c
 HandleInput(); // 0x36f2: 00000010
 ShowText((4040)"I stood my ground and waited for its attack. I let it draw as close as I could. Inside its mouth. If I can just fire blindly in there."); // 0x36f6: 0000100c
 HandleInput(); // 0x36fc: 00000010
@@ -2951,9 +2951,9 @@ LoadSecondEffect(0x65, 0x1, 0x1); // 0x3850: 0000306e
 PlayMusic(0x67); // 0x385a: 0000106c
 ShowText((1232)"A cross is mounted on the front wall. Long benches are lined up on both sides of a small walkway. It was as if time had stopped for this familiar style church."); // 0x3860: 0000100c
 HandleInput(); // 0x3866: 00000010
-ShowText((1233)"In front of the altar a sly looking woman with cold eyes looks down at me with a eerie grin. As I walked up to her stepping one step at a time she gazed at me without blinking. She looked as if she had predicted that I would arrive."); // 0x386a: 0000100c
+ShowText((1233)"In front of the altar a sly looking woman with cold eyes looks down at me with an eerie grin. As I walked up to her stepping one step at a time she gazed at me without blinking. She looked as if she had predicted that I would arrive."); // 0x386a: 0000100c
 HandleInput(); // 0x3870: 00000010
-ShowText((1234)"¥"Were you ringing that bell?¥" The woman snorted with a humph. ¥"I've been expecting you. It was foretold by Gryomancy.¥" ¥"What are you talking about?¥""); // 0x3874: 0000100c
+ShowText((1234)"¥"Were you ringing that bell?¥" The woman snorted with a humph. ¥"I've been expecting you. It was foretold by Gyromancy.¥" ¥"What are you talking about?¥""); // 0x3874: 0000100c
 HandleInput(); // 0x387a: 00000010
 ShowText((1235)"¥"I knew you'd come. You want the girl, right?¥" ¥"The girl? You're talking about Cheryl?¥" My eyes grew wide."); // 0x387e: 0000100c
 HandleInput(); // 0x3884: 00000010
@@ -3145,13 +3145,13 @@ OP_0x65(); // 0x3c76: 00000065
 LoadSecondEffect(0xd, 0x1, 0x0, 0x1); // 0x3c7a: 0000406e
 LoadSecondEffect(0x56, 0x1, 0x1, 0x1); // 0x3c86: 0000406e
 PlayMusic(0x67, 0x1); // 0x3c92: 0000206c
-ShowText((1261)"¥"Wait......¥" I hold my right hand out to try and stop the man. ¥"Hold it... Stop! Don't shoot! Wait...I'm not here to fight.¥""); // 0x3c9a: 0000100c
+ShowText((1261)"¥"Wait...¥" I hold my right hand out to try and stop the man. ¥"Hold it... Stop! Don't shoot! Wait... I'm not here to fight.¥""); // 0x3c9a: 0000100c
 HandleInput(); // 0x3ca0: 00000010
 LoadSecondEffect(0x56, 0x2, 0x1); // 0x3ca4: 0000306e
 LoadSecondEffect(0x0, 0x0, 0x1); // 0x3cae: 0000306e
 ShowText((1262)"The man calms down and lowers his readied right arm. ¥"My name is Harry Mason. I'm in town on vacation.¥" I said all of this without pausing, and then the man took a deep breath and began to speak."); // 0x3cb8: 0000100c
 HandleInput(); // 0x3cbe: 00000010
-ShowText((1263)"¥"Thank god. Another human being.¥" ¥"Do you work here?¥" I was truly relived. Silent Hill, which has become a habitat for strange monsters... Those words showed his candid questioning of the situation."); // 0x3cc2: 0000100c
+ShowText((1263)"¥"Thank God. Another human being.¥" ¥"Do you work here?¥" I was truly relived. Silent Hill, which has become a habitat for strange monsters... Those words showed his candid questioning of the situation."); // 0x3cc2: 0000100c
 HandleInput(); // 0x3cc8: 00000010
 Jump(L_0x3cd2); // 0x3ccc: 00001001
 L_0x3cd2:
@@ -3207,7 +3207,7 @@ CleanScreen(); // 0x3de6: 00000064
 LoadBackground(0x6b); // 0x3dea: 00001069
 OP_0x65(); // 0x3df0: 00000065
 PlayMusic(0x67, 0x1); // 0x3df4: 0000206c
-Choice((140)"What...is this...?", (141)"A ) Check to see if there is anything else.", (142)"B ) Go after Kaufmann."); // 0x3dfc: 00003011
+Choice((140)"What... is this...?", (141)"A ) Check to see if there is anything else.", (142)"B ) Go after Kaufmann."); // 0x3dfc: 00003011
 Branch4(0x632, L_0x3e12); // 0x3e06: 00001004
 Jump(L_0x3e26); // 0x3e0c: 00001001
 L_0x3e12:
@@ -3274,7 +3274,7 @@ OP_0x65(); // 0x3f3e: 00000065
 PlaySecondSoundFx(0x1f); // 0x3f42: 00001073
 ShowText((1283)"The next room looks to be the kitchen. I guess that the food for patients is probably prepared here. Various bronze cooking utensils are neatly arranged in order on the stainless steel countertop. It does not appear that anything terribly important is here."); // 0x3f48: 0000100c
 HandleInput(); // 0x3f4e: 00000010
-ShowText((1284)"I carefully look through the various cooking utensils. Inside a large pot there is......nothing at all."); // 0x3f52: 0000100c
+ShowText((1284)"I carefully look through the various cooking utensils. Inside a large pot there is... nothing at all."); // 0x3f52: 0000100c
 HandleInput(); // 0x3f58: 00000010
 ShowText((1285)"While continuing to search to see if there might be some clue here or not I notice that on the far wall various objects have been scattered about."); // 0x3f5c: 0000100c
 HandleInput(); // 0x3f62: 00000010
@@ -3287,7 +3287,7 @@ Area(0x5a); // 0x3f7e: 00001026
 CleanScreen(); // 0x3f84: 00000064
 LoadBackground(0x53); // 0x3f88: 00001069
 OP_0x65(); // 0x3f8e: 00000065
-Choice((150)"I reach out my hand towards the thing in front of me.", (151)"A ) Pick up the pet bottle.", (152)"B ) Pick up the kitchen knife."); // 0x3f92: 00003011
+Choice((150)"I reach out my hand towards the thing in front of me.", (151)"A ) Pick up the plastic bottle.", (152)"B ) Pick up the kitchen knife."); // 0x3f92: 00003011
 Branch4(0x640, L_0x3fa8); // 0x3f9c: 00001004
 Jump(L_0x3fbc); // 0x3fa2: 00001001
 L_0x3fa8:
@@ -3302,9 +3302,9 @@ Area(0x5b); // 0x3fc4: 00001026
 CleanScreen(); // 0x3fca: 00000064
 LoadBackground(0x53); // 0x3fce: 00001069
 OP_0x65(); // 0x3fd4: 00000065
-ShowText((1287)"I move past one of the sinks and notice an empty pet bottle sitting on the end of the counter."); // 0x3fd8: 0000100c
+ShowText((1287)"I move past one of the sinks and notice an empty plastic bottle sitting on the end of the counter."); // 0x3fd8: 0000100c
 HandleInput(); // 0x3fde: 00000010
-ShowText((1288)"¥"Perhaps this might come in handy for something.¥" I mutter this and grab the empty pet bottle. Then I leave the kitchen."); // 0x3fe2: 0000100c
+ShowText((1288)"¥"Perhaps this might come in handy for something.¥" I mutter this and grab the empty plastic bottle. Then I leave the kitchen."); // 0x3fe2: 0000100c
 HandleInput(); // 0x3fe8: 00000010
 Jump(L_0x3ff2); // 0x3fec: 00001001
 L_0x3ff2:
@@ -3335,7 +3335,7 @@ CleanScreen(); // 0x4072: 00000064
 LoadBackground(0x54); // 0x4076: 00001069
 OP_0x65(); // 0x407c: 00000065
 PlayMusic(0x6e); // 0x4080: 0000106c
-ChoiceIdx(0x5, (160)"If I use the pet bottle...", (161)"A ) Scoop up the red liquid.", (162)"B ) Scoop up the blue liquid.", (163)"C ) Scoop up the mixture of purple liquid."); // 0x4086: 00005035
+ChoiceIdx(0x5, (160)"If I use the plastic bottle...", (161)"A ) Scoop up the red liquid.", (162)"B ) Scoop up the blue liquid.", (163)"C ) Scoop up the mixture of purple liquid."); // 0x4086: 00005035
 Branch4(0x64e, L_0x40a0); // 0x4094: 00001004
 Jump(L_0x40c4); // 0x409a: 00001001
 L_0x40a0:
@@ -3355,9 +3355,9 @@ CleanScreen(); // 0x40d2: 00000064
 LoadBackground(0x54); // 0x40d6: 00001069
 OP_0x65(); // 0x40dc: 00000065
 PlayMusic(0x6e, 0x1); // 0x40e0: 0000206c
-ShowText((1291)"I...get out the pet bottle and use a fragment of the bottom section of one of the broken bottles to pour the vermilion liquid into the it."); // 0x40e8: 0000100c
+ShowText((1291)"I... get out the plastic bottle and use a fragment of the bottom section of one of the broken bottles to pour the vermilion liquid into it."); // 0x40e8: 0000100c
 HandleInput(); // 0x40ee: 00000010
-ShowText((1292)"The sticky liquid drips into the pet bottle. The last drop lingered, but once it finally hit the surface of the liquid already inside the pet bottle I tightly closed the cap and then left the Director's Office."); // 0x40f2: 0000100c
+ShowText((1292)"The sticky liquid drips into the plastic bottle. The last drop lingered, but once it finally hit the surface of the liquid already inside the plastic bottle I tightly closed the cap and then left the Director's Office."); // 0x40f2: 0000100c
 HandleInput(); // 0x40f8: 00000010
 Jump(L_0x4102); // 0x40fc: 00001001
 L_0x4102:
@@ -3462,9 +3462,9 @@ LoadSecondEffect(0x56, 0x2, 0x1); // 0x431a: 0000306e
 LoadSecondEffect(0x0, 0x0, 0x1); // 0x4324: 0000306e
 ShowText((4049)"I instantly ready my gun. That plump man appeared to realize that I was a human, but as soon as he saw the gun his eyes grew wide."); // 0x432e: 0000100c
 HandleInput(); // 0x4334: 00000010
-ShowText((4050)"¥"Hold it... Stop! Don't shoot! Wait...I'm not here to fight.¥" After I lowered my gun the man sat down in his chair in a way that showed that he was relieved. ¥"Thank god. Another human being.¥""); // 0x4338: 0000100c
+ShowText((4050)"¥"Hold it... Stop! Don't shoot! Wait... I'm not here to fight.¥" After I lowered my gun the man sat down in his chair in a way that showed that he was relieved. ¥"Thank God. Another human being.¥""); // 0x4338: 0000100c
 HandleInput(); // 0x433e: 00000010
-ShowText((4051)"¥"My name is Harry Mason. I'm in town on vacation...Do you work here?¥""); // 0x4342: 0000100c
+ShowText((4051)"¥"My name is Harry Mason. I'm in town on vacation... Do you work here?¥""); // 0x4342: 0000100c
 HandleInput(); // 0x4348: 00000010
 ShowText((4052)"The man nodded. I was truly relieved. Silent Hill, which has become a habitat for strange monsters... This is my first contact with someone from this town."); // 0x434c: 0000100c
 HandleInput(); // 0x4352: 00000010
@@ -3498,9 +3498,9 @@ CleanScreen(); // 0x43dc: 00000064
 LoadBackground(0x54); // 0x43e0: 00001069
 OP_0x65(); // 0x43e6: 00000065
 PlayMusic(0x6e, 0x1); // 0x43ea: 0000206c
-ShowText((4056)"I...get out the pet bottle and use a fragment of the bottom section of one of the broken bottles to pour the blue liquid into the it."); // 0x43f2: 0000100c
+ShowText((4056)"I... get out the plastic bottle and use a fragment of the bottom section of one of the broken bottles to pour the blue liquid into it."); // 0x43f2: 0000100c
 HandleInput(); // 0x43f8: 00000010
-ShowText((4057)"The sticky liquid drips into the pet bottle. The last drop lingered, but once it finally hit the surface of the liquid already inside the pet bottle I tightly closed the cap and then left the Director's Office."); // 0x43fc: 0000100c
+ShowText((4057)"The sticky liquid drips into the plastic bottle. The last drop lingered, but once it finally hit the surface of the liquid already inside the plastic bottle I tightly closed the cap and then left the Director's Office."); // 0x43fc: 0000100c
 HandleInput(); // 0x4402: 00000010
 CleanScreen(); // 0x4406: 00000064
 LoadBackground(0x0); // 0x440a: 00001069
@@ -3513,9 +3513,9 @@ CleanScreen(); // 0x4428: 00000064
 LoadBackground(0x54); // 0x442c: 00001069
 OP_0x65(); // 0x4432: 00000065
 PlayMusic(0x6e, 0x1); // 0x4436: 0000206c
-ShowText((4058)"I...get out the pet bottle and use a fragment of the bottom section of one of the broken bottles to pour the purple liquid into the it."); // 0x443e: 0000100c
+ShowText((4058)"I... get out the plastic bottle and use a fragment of the bottom section of one of the broken bottles to pour the purple liquid into it."); // 0x443e: 0000100c
 HandleInput(); // 0x4444: 00000010
-ShowText((4059)"The sticky liquid drips into the pet bottle. The last drop lingered, but once it finally hit the surface of the liquid already inside the pet bottle I tightly closed the cap and then left the Director's Office."); // 0x4448: 0000100c
+ShowText((4059)"The sticky liquid drips into the plastic bottle. The last drop lingered, but once it finally hit the surface of the liquid already inside the plastic bottle I tightly closed the cap and then left the Director's Office."); // 0x4448: 0000100c
 HandleInput(); // 0x444e: 00000010
 CleanScreen(); // 0x4452: 00000064
 LoadBackground(0x0); // 0x4456: 00001069
@@ -3602,7 +3602,7 @@ LoadSecondEffect(0x0, 0x0, 0x1); // 0x4622: 0000306e
 CleanScreen(); // 0x462c: 00000064
 LoadBackground(0x0); // 0x4630: 00001069
 OP_0x65(); // 0x4636: 00000065
-ShowText((1318)"I cannot give up. When the final bullet loaded into my gun hits it finally stops laughing. This time it is face down and I begin crushing it with my foot. Finally...it completely stops moving."); // 0x463a: 0000100c
+ShowText((1318)"I cannot give up. When the final bullet loaded into my gun hits it finally stops laughing. This time it is face down and I begin crushing it with my foot. Finally... it completely stops moving."); // 0x463a: 0000100c
 HandleInput(); // 0x4640: 00000010
 Jump(L_0xa902); // 0x4644: 00001001
 L_0x464a:
@@ -3681,7 +3681,7 @@ ShowText((1331)"Some chemicals have been placed on the table that is next to the
 HandleInput(); // 0x47d8: 00000010
 ShowText((9901)"¥"To create it you must come up with one deciliter of liquid and pour it into the test tube. No more or no less, that man had said. But there are no graduations on the beakers. This makes it impossible to come up with one deciliter using these three large beakers.¥""); // 0x47dc: 0000100c
 HandleInput(); // 0x47e2: 00000010
-ShowText((9902)"¥"Explanation of Controls¥" Use the d-pad to select a beaker that contains liquid and then confirm with the A button. Then choose the beaker that you wish to move the liquid to and press the A button to move the liquid."); // 0x47e6: 0000100c
+ShowText((9902)"Explanation of Controls: Use the Control Pad to select a beaker that contains liquid and then confirm with the A Button. Then choose the beaker that you wish to move the liquid to and press the A Button to move the liquid."); // 0x47e6: 0000100c
 HandleInput(); // 0x47ec: 00000010
 ShowText((9918)"Using the 10 deciliter, 7 deciliter, and 5 deciliter beakers you must create an amount of exactly one deciliter."); // 0x47f0: 0000100c
 HandleInput(); // 0x47f6: 00000010
@@ -3739,7 +3739,7 @@ OP_0x65(); // 0x48f8: 00000065
 PlayMusic(0x6e, 0x1); // 0x48fc: 0000206c
 ShowText((1335)"If there is an important clue inside this cabinet then I should be able to open it right away. But then I gradually come to understand that there is no need to do so."); // 0x4904: 0000100c
 HandleInput(); // 0x490a: 00000010
-ShowText((1336)"The necessity of the cabinet here is thin, as anything could be used to satisfy the requirement; if something is needed to block my path then a bunch of stones could work just as well. I thought this as I looked at the scratches on the floor that were the same same width as the cabinet."); // 0x490e: 0000100c
+ShowText((1336)"The necessity of the cabinet here is thin, as anything could be used to satisfy the requirement; if something is needed to block my path then a bunch of stones could work just as well. I thought this as I looked at the scratches on the floor that were the same width as the cabinet."); // 0x490e: 0000100c
 HandleInput(); // 0x4914: 00000010
 Jump(L_0x491e); // 0x4918: 00001001
 L_0x491e:
@@ -3887,7 +3887,7 @@ HandleInput(); // 0x4bec: 00000010
 PlaySecondSoundFx(0x19); // 0x4bf0: 00001073
 ShowText((1370)"April 19"); // 0x4bf6: 0000100c
 HandleInput(); // 0x4bfc: 00000010
-ShowText((1371)"I must get out of here. For the first time in a while I have wore my favorite pendant. Does it look good on me?"); // 0x4c00: 0000100c
+ShowText((1371)"I must get out of here. For the first time in a while, I have worn my favorite pendant. Does it look good on me?"); // 0x4c00: 0000100c
 HandleInput(); // 0x4c06: 00000010
 ShowText((1372)"I will write about the results here tomorrow."); // 0x4c0a: 0000100c
 HandleInput(); // 0x4c10: 00000010
@@ -3922,7 +3922,7 @@ ShowText((1378)"I head for the examination room on the first floor. All the myst
 HandleInput(); // 0x4ca4: 00000010
 OP_0x29(); // 0x4ca8: 00000029
 PlaySecondSoundFx(0x1f); // 0x4cac: 00001073
-ShowText((1379)"When I open the door to the examination room I feel the presence of a person and stop moving. The inside of the room is dark. ......Someone is here."); // 0x4cb2: 0000100c
+ShowText((1379)"When I open the door to the examination room I feel the presence of a person and stop moving. The inside of the room is dark... Someone is here."); // 0x4cb2: 0000100c
 HandleInput(); // 0x4cb8: 00000010
 Jump(L_0x4cc2); // 0x4cbc: 00001001
 L_0x4cc2:
@@ -3950,7 +3950,7 @@ OP_0x65(); // 0x4d28: 00000065
 PlayMusic(0x71); // 0x4d2c: 0000106c
 ShowText((1380)"Once the woman realized that I was a human she ran towards me and threw her arms around me like a child would."); // 0x4d32: 0000100c
 HandleInput(); // 0x4d38: 00000010
-ShowText((1381)"¥"Finally. Someone else who's OK.......¥" After mumbling those words in a tearful voice she held me more tightly."); // 0x4d3c: 0000100c
+ShowText((1381)"¥"Finally. Someone else who's OK...¥" After mumbling those words in a tearful voice she held me more tightly."); // 0x4d3c: 0000100c
 HandleInput(); // 0x4d42: 00000010
 ShowText((1382)"¥"Who are you?¥" ¥"My name's Lisa Garland. What's yours?¥" ¥"Harry Mason.¥""); // 0x4d46: 0000100c
 HandleInput(); // 0x4d4c: 00000010
@@ -3964,7 +3964,7 @@ CleanScreen(); // 0x4d6e: 00000064
 LoadBackground(0x6a); // 0x4d72: 00001069
 OP_0x65(); // 0x4d78: 00000065
 PlayMusic(0x71, 0x1); // 0x4d7c: 0000206c
-ShowText((1384)"At the moment I was about to speak the woman began talking."); // 0x4d84: 0000100c
+ShowText((1384)"At the moment I was about to speak, the woman began talking."); // 0x4d84: 0000100c
 HandleInput(); // 0x4d8a: 00000010
 ShowText((1385)"¥"Harry, tell me what's happening here. Where is everybody? I must have gotten knocked out. When I came to, everyone was gone.¥" Her voice did not feel like it was coming from her body, and was accompanied by a strange reverberation."); // 0x4d8e: 0000100c
 HandleInput(); // 0x4d94: 00000010
@@ -4015,7 +4015,7 @@ LoadSecondEffect(0xd, 0x1, 0x0); // 0x4e72: 0000306e
 PlayMusic(0x68); // 0x4e7c: 0000106c
 ShowText((1398)"After a while I notice that my body is freezing cold. It is as if I am dead. But I am clearly conscious. Where is Lisa? I was definitely talking to her in this examination room."); // 0x4e82: 0000100c
 HandleInput(); // 0x4e88: 00000010
-ShowText((1399)"I no longer feel the evil presence that I felt in this room, no in this entire hospital up until just before. From the window soft light is pouring into the room."); // 0x4e8c: 0000100c
+ShowText((1399)"I no longer feel the evil presence that I felt in this room, no, in this entire hospital up until just before. From the window soft light is pouring into the room."); // 0x4e8c: 0000100c
 HandleInput(); // 0x4e92: 00000010
 PlaySecondSoundFx(0x1f); // 0x4e96: 00001073
 ShowText((1400)"¥"Was I dreaming?¥" As I slowly get up I hear the sound of a door opening. I instantly look toward the source of the sound. The creepy woman I met at the church was standing there with an expressionless look on her face."); // 0x4e9c: 0000100c
@@ -4025,7 +4025,7 @@ LoadBackground(0x6b); // 0x4eaa: 00001069
 LoadEffect(0x0, 0x0, 0x0); // 0x4eb0: 0000306d
 OP_0x65(); // 0x4eba: 00000065
 LoadSecondEffect(0x21, 0x1, 0x1); // 0x4ebe: 0000306e
-ShowText((1401)"¥"You were too late.¥" ¥"It's you...¥" ¥"Yes. Dahlia Gillespie¥" ¥"Tell me everything you know. What's going on?¥""); // 0x4ec8: 0000100c
+ShowText((1401)"¥"You were too late.¥" ¥"It's you...¥" ¥"Yes. Dahlia Gillespie.¥" ¥"Tell me everything you know. What's going on?¥""); // 0x4ec8: 0000100c
 HandleInput(); // 0x4ece: 00000010
 ShowText((1402)"¥"Darkness.¥" She responded before I was even done speaking. ¥"The town is being devoured by darkness.¥" The woman continues while maintaining a devout look."); // 0x4ed2: 0000100c
 HandleInput(); // 0x4ed8: 00000010
@@ -4035,7 +4035,7 @@ ShowText((1404)"¥"Believe the evidence of your eyes.¥" So I should believe the
 HandleInput(); // 0x4eec: 00000010
 ShowText((1405)"¥"The other church in this town. That is your destination. This is beyond my abilities. Only you can stop it now. Have you not seen the crest marked on the ground all over town?¥""); // 0x4ef0: 0000100c
 HandleInput(); // 0x4ef6: 00000010
-ShowText((1406)"¥"So that's what I saw in the schoolyard. What does it mean?¥" ¥"It is the mark of Samael... Don't let it be completed.¥" ¥"Hey! wait!¥""); // 0x4efa: 0000100c
+ShowText((1406)"¥"So that's what I saw in the schoolyard. What does it mean?¥" ¥"It is the mark of Samael... Don't let it be completed.¥" ¥"Hey! Wait!¥""); // 0x4efa: 0000100c
 HandleInput(); // 0x4f00: 00000010
 PlaySecondSoundFx(0x1f); // 0x4f04: 00001073
 LoadSecondEffect(0x21, 0x0, 0x1); // 0x4f0a: 0000306e
@@ -4112,7 +4112,7 @@ LoadSecondEffect(0x0, 0x0, 0x1); // 0x509e: 0000306e
 CleanScreen(); // 0x50a8: 00000064
 LoadBackground(0x0); // 0x50ac: 00001069
 OP_0x65(); // 0x50b2: 00000065
-ShowText((1318)"I cannot give up. When the final bullet loaded into my gun hits it finally stops laughing. This time it is face down and I begin crushing it with my foot. Finally...it completely stops moving."); // 0x50b6: 0000100c
+ShowText((1318)"I cannot give up. When the final bullet loaded into my gun hits it finally stops laughing. This time it is face down and I begin crushing it with my foot. Finally... it completely stops moving."); // 0x50b6: 0000100c
 HandleInput(); // 0x50bc: 00000010
 Jump(L_0xa902); // 0x50c0: 00001001
 L_0x50c6:
@@ -4141,9 +4141,9 @@ LoadBackground(0x0); // 0x5146: 00001069
 OP_0x65(); // 0x514c: 00000065
 PlayMusic(0x6e, 0x1); // 0x5150: 0000206c
 PlaySecondSoundFx(0x25); // 0x5158: 00001073
-ShowText((4064)"Putting force into my fists I pounded the cabinet's small wooden doors until they broke. Inside there is...nothing of particular value."); // 0x515e: 0000100c
+ShowText((4064)"Putting force into my fists I pounded the cabinet's small wooden doors until they broke. Inside there is... nothing of particular value."); // 0x515e: 0000100c
 HandleInput(); // 0x5164: 00000010
-ShowText((4065)"At that time I noticed that I could feel cold air coming from behind the cabinet. And at the same time...I also noticed marks that looked like they had been left from dragging something on the floor."); // 0x5168: 0000100c
+ShowText((4065)"At that time I noticed that I could feel cold air coming from behind the cabinet. And at the same time... I also noticed marks that looked like they had been left from dragging something on the floor."); // 0x5168: 0000100c
 HandleInput(); // 0x516e: 00000010
 Jump(L_0x491e); // 0x5172: 00001001
 L_0x5178:
@@ -4184,7 +4184,7 @@ ShowText((4075)"¥"０２/４Ｙ　ＤＮＡ¥""); // 0x5226: 0000100c
 HandleInput(); // 0x522c: 00000010
 ShowText((4076)"What is this? The incomprehensible letters had been scribbled there."); // 0x5230: 0000100c
 HandleInput(); // 0x5236: 00000010
-ShowText((4605)"A feeling of doubt runs throughout my chest. I removed the picture from the frame. I place it in the diary that was sitting beside the picture frame. I then held the diary tightly under my arm and left the room. 5001: ¥"Hello...hello!?¥" The phone had suddenly gone dead. She tried to call back right away; however, the call would not go through."); // 0x523a: 0000100c
+ShowText((4605)"A feeling of doubt runs throughout my chest. I removed the picture from the frame. I place it in the diary that was sitting beside the picture frame. I then held the diary tightly under my arm and left the room."); // 0x523a: 0000100c
 HandleInput(); // 0x5240: 00000010
 Jump(L_0x4c60); // 0x5244: 00001001
 L_0x524a:
@@ -4197,7 +4197,7 @@ ShowText((4077)"I readied the handgun. ¥"So there's more of you bastards...!¥"
 HandleInput(); // 0x526c: 00000010
 ShowText((4078)"At the moment I was about to pull the trigger a woman shrieked. ¥"Wait, don't shoot! I'm human!¥""); // 0x5270: 0000100c
 HandleInput(); // 0x5276: 00000010
-ShowText((4079)"With my gun still readied, I carefully looked at the woman under the desk. ¥"What...what are you doing under there?¥""); // 0x527a: 0000100c
+ShowText((4079)"With my gun still readied, I carefully looked at the woman under the desk. ¥"What...? What are you doing under there?¥""); // 0x527a: 0000100c
 HandleInput(); // 0x5280: 00000010
 Jump(L_0x4d0a); // 0x5284: 00001001
 L_0x528a:
@@ -4309,7 +4309,7 @@ PlayMusic(0x67, 0x1); // 0x54bc: 0000206c
 LoadSecondEffect(0x22, 0x1, 0x1); // 0x54c4: 0000306e
 ShowText((1429)"¥"Wait. We don't know what's back there. I'd better check it out first.¥""); // 0x54ce: 0000100c
 HandleInput(); // 0x54d4: 00000010
-ShowText((1430)"I'm a cop, I should go.¥" ¥"No. I'm going.¥" I said in a rough tone. ¥"Alright. I'll cover you from here. Be careful. If anything looks fishy, get back here on the double.¥" ¥"Okay.¥""); // 0x54d8: 0000100c
+ShowText((1430)"¥"I'm a cop, I should go.¥" ¥"No. I'm going.¥" I said in a rough tone. ¥"Alright. I'll cover you from here. Be careful. If anything looks fishy, get back here on the double.¥" ¥"Okay.¥""); // 0x54d8: 0000100c
 HandleInput(); // 0x54de: 00000010
 ShowText((1431)"I peer inside the hidden passage. Inside it looks like an unseen barrier of darkness has been set up, which makes it look like a place no one should enter. I intuitively sense that it would be dangerous to move into this passage. It is that kind of passage."); // 0x54e2: 0000100c
 HandleInput(); // 0x54e8: 00000010
@@ -4321,7 +4321,7 @@ ShowText((1434)"I met this nurse...Lisa. It's like I was there, but not really. 
 HandleInput(); // 0x5506: 00000010
 ShowText((1435)"¥"I have no idea what you're talking about, Harry.¥" Cybil spoke while shaking her head from side to side. ¥"Oh... I was just wondering. Never mind.¥" ¥"Harry. You're tired.¥" ¥"Yeah, maybe...¥""); // 0x550a: 0000100c
 HandleInput(); // 0x5510: 00000010
-ShowText((1436)"Am I tired? Yes, I am tired. If that is all it is then that is fine. If my being tired is what caused me to see all the hallucinations up to this point then Cheryl should return to me."); // 0x5514: 0000100c
+ShowText((1436)"Am I tired? Yes, I am tired. If that is all it is, then that is fine. If my being tired is what caused me to see all the hallucinations up to this point then Cheryl should return to me."); // 0x5514: 0000100c
 HandleInput(); // 0x551a: 00000010
 ShowText((1437)"The only thing is the sensation I am feeling is not that of being tired. Rather my body feels as if I have been on the floor sleeping continuously like a human in cold sleep. And I am feeling the agonizing suffering of not easily being able to escape from that state."); // 0x551e: 0000100c
 HandleInput(); // 0x5524: 00000010
@@ -4342,7 +4342,7 @@ OP_0x65(); // 0x5570: 00000065
 PlayMusic(0x6e); // 0x5574: 0000106c
 ShowText((1439)"I made my way into the room at the end of the passage. It is small, and the smell of something having been burned is in the air. Once I saw an altar appear in the darkness I realized that this is the ¥"church¥" that Dahlia was talking about."); // 0x557a: 0000100c
 HandleInput(); // 0x5580: 00000010
-ShowText((1440)"I look around the area. An axe have been displayed on the wall. But nothing else stands out. While shaking my head I decide to try going back through the passage I came from. And at that moment...a light bright enough to make me look away emanates from the altar."); // 0x5584: 0000100c
+ShowText((1440)"I look around the area. An axe is being displayed on the wall. But nothing else stands out. While shaking my head I decide to try going back through the passage I came from. And at that moment... a light bright enough to make me look away emanates from the altar."); // 0x5584: 0000100c
 HandleInput(); // 0x558a: 00000010
 PlaySoundFx(0x26); // 0x558e: 00001072
 LoadSecondEffect(0x37, 0x1, 0x1); // 0x5594: 0000306e
@@ -4363,14 +4363,14 @@ LoadBackground(0x0); // 0x55e2: 00001069
 OP_0x65(); // 0x55e8: 00000065
 OP_0x2c(0x2, 0x1); // 0x55ec: 0000202c
 OP_0x2c(0x3, 0x1); // 0x55f4: 0000202c
-ShowText((1443)"...rry? Are you OK? Harry? Harry? .............................. Where am I? Harry. Lisa... Then I'm in the hospital."); // 0x55fc: 0000100c
+ShowText((1443)"¥"...rry? Are you OK? Harry? Harry?¥" .............................. ¥"Where am I?¥" ¥"Harry.¥" ¥"Lisa... Then I'm in the hospital.¥""); // 0x55fc: 0000100c
 HandleInput(); // 0x5602: 00000010
 CleanScreen(); // 0x5606: 00000064
 LoadBackground(0x69); // 0x560a: 00001069
 OP_0x65(); // 0x5610: 00000065
 PlaySoundFx(0x39); // 0x5614: 00001072
 LoadSecondEffect(0x33, 0x1, 0x1); // 0x561a: 0000306e
-ShowText((1444)"You were having a bad dream. Was I? Hey, you don't look too good. Are you OK? I'm fine. Nothing you need to worry about. Well, if you're sure..."); // 0x5624: 0000100c
+ShowText((1444)"¥"You were having a bad dream.¥" ¥"Was I? Hey, you don't look too good. Are you OK?¥" ¥"I'm fine. Nothing you need to worry about.¥" ¥"Well, if you're sure..."); // 0x5624: 0000100c
 HandleInput(); // 0x562a: 00000010
 Jump(L_0x5634); // 0x562e: 00001001
 L_0x5634:
@@ -4382,24 +4382,24 @@ LoadEffect(0x33, 0x1, 0x1, 0x2); // 0x564c: 0000406d
 OP_0x65(); // 0x5658: 00000065
 PlaySoundFx(0x39, 0x1); // 0x565c: 00002072
 LoadSecondEffect(0x33, 0x1, 0x1, 0x1); // 0x5664: 0000406e
-ShowText((1445)"Lisa... Do you know a woman named Dahlia Gillespie?"); // 0x5670: 0000100c
+ShowText((1445)"Lisa... Do you know a woman named Dahlia Gillespie?¥""); // 0x5670: 0000100c
 HandleInput(); // 0x5676: 00000010
-ShowText((1446)"Oh yeah, that crazy Gillespie lady. She's kinda' famous around here. She never sees anybody, so I don't know that much about her."); // 0x567a: 0000100c
+ShowText((1446)"¥"Oh yeah, that crazy Gillespie lady. She's kinda' famous around here. She never sees anybody, so I don't know that much about her."); // 0x567a: 0000100c
 HandleInput(); // 0x5680: 00000010
-ShowText((1447)"But I heard her kid died in a fire, and supposedly she's been crazy ever since. Well, she says the town is being devoured by the darkness. Do you have any idea what she's talking about?"); // 0x5684: 0000100c
+ShowText((1447)"But I heard her kid died in a fire, and supposedly she's been crazy ever since.¥" ¥"Well, she says the town is being devoured by the darkness. Do you have any idea what she's talking about?¥""); // 0x5684: 0000100c
 HandleInput(); // 0x568a: 00000010
-ShowText((1448)"The town...devoured by the darkness. Yes, I think I do. Before this place was turned into a resort, the townspeople here were on the quiet side."); // 0x568e: 0000100c
+ShowText((1448)"¥"The town... devoured by the darkness. Yes, I think I do. Before this place was turned into a resort, the townspeople here were on the quiet side."); // 0x568e: 0000100c
 HandleInput(); // 0x5694: 00000010
 ShowText((1449)"Everybody followed some kind of queer religion. Weird occult stuff... Black magic, that kind of thing."); // 0x5698: 0000100c
 HandleInput(); // 0x569e: 00000010
 ShowText((1450)"As young people moved away, the people figured they'd been summoned by the gods. Evidently, things like that used to happen around here all the time."); // 0x56a2: 0000100c
 HandleInput(); // 0x56a8: 00000010
-ShowText((1451)"Before the resort, there wasn't really anything else out here. Everyone was so flipped out. Gotta blame it on something. Then a lot of new people came in and everybody clammed up about it."); // 0x56ac: 0000100c
+ShowText((1451)"Before the resort, there wasn't really anything else out here. Everyone was so flipped out. Gotta blame it on something. Then a lot of new people came in and everybody clammed up about it.¥""); // 0x56ac: 0000100c
 HandleInput(); // 0x56b2: 00000010
 LoadSecondEffect(0x33, 0x2, 0x1); // 0x56b6: 0000306e
-ShowText((1452)"A cult... Last time I heard anything about it was, gosh, years ago... When several people connected with developing the town died in accidents. People said it was a curse."); // 0x56c0: 0000100c
+ShowText((1452)"¥"A cult...¥" ¥"Last time I heard anything about it was, gosh, years ago... When several people connected with developing the town died in accidents. People said it was a curse."); // 0x56c0: 0000100c
 HandleInput(); // 0x56c6: 00000010
-ShowText((1453)"Oh, I'm sorry. I'm rambling... I'll shut up. ..............................."); // 0x56ca: 0000100c
+ShowText((1453)"Oh, I'm sorry. I'm rambling... I'll shut up.¥" ..............................."); // 0x56ca: 0000100c
 HandleInput(); // 0x56d0: 00000010
 LoadSecondEffect(0x0, 0x0, 0x1); // 0x56d4: 0000306e
 CleanScreen(); // 0x56de: 00000064
@@ -4458,7 +4458,7 @@ ShowText((4085)"........."); // 0x57f2: 0000100c
 HandleInput(); // 0x57f8: 00000010
 ShowText((4086)"Drowsiness is threatening my consciousness. It is not unreasonable. We left past midnight and without sleeping a wink I have been walking all over town while searching for Cheryl."); // 0x57fc: 0000100c
 HandleInput(); // 0x5802: 00000010
-ShowText((4087)"I am on the verge of falling asleep ............ A scream from what I think was Cybil brought me round."); // 0x5806: 0000100c
+ShowText((4087)"I'm on the verge of falling asleep... A scream from what I think was Cybil brought me round."); // 0x5806: 0000100c
 HandleInput(); // 0x580c: 00000010
 ShowText((4088)"I know I heard it. I energetically stand up and rush into the passage. There is something at the end of the passage. Something dangerous is..."); // 0x5810: 0000100c
 HandleInput(); // 0x5816: 00000010
@@ -4474,7 +4474,7 @@ OP_0x65(); // 0x5846: 00000065
 PlayMusic(0x68); // 0x584a: 0000106c
 ShowText((1459)"The town has turned into that nightmarish world. It's as if the danger in this town increases with every second. In order to find Lisa I turn on the flashlight on my chest and begin to run at full speed."); // 0x5850: 0000100c
 HandleInput(); // 0x5856: 00000010
-ShowText((1460)"I left the antique shop with the intention of reuniting with Lisa, but I discover that all the roads leading to the hospital are blocked. With no other choice I enter the shopping mall ¥"Town Center¥" in the shopping district."); // 0x585a: 0000100c
+ShowText((1460)"I left the antique shop with the intention of reuniting with Lisa, but I discover that all the roads leading to the hospital are blocked. With no other choice, I enter the shopping mall ¥"Town Center¥" in the shopping district."); // 0x585a: 0000100c
 HandleInput(); // 0x5860: 00000010
 OP_0x2c(0x3, 0x1); // 0x5864: 0000202c
 Jump(L_0x5872); // 0x586c: 00001001
@@ -4496,9 +4496,9 @@ Area(0x90); // 0x58ba: 00001026
 LoadBackground(0x0); // 0x58c0: 00001069
 LoadSecondEffect(0x38, 0x1, 0x1); // 0x58c6: 0000306e
 PlaySoundFx(0x27); // 0x58d0: 00001072
-ShowText((1463)"Suddenly light overflows from out of the monitors in the hall. A bound Cheryl is displayed on the screens."); // 0x58d6: 0000100c
+ShowText((1463)"Suddenly light overflows from the monitors in the hall. A bound Cheryl is displayed on the screens."); // 0x58d6: 0000100c
 HandleInput(); // 0x58dc: 00000010
-ShowText((1464)"¥"Daddy...Help me!¥" ¥"Cheryl!¥""); // 0x58e0: 0000100c
+ShowText((1464)"¥"Daddy... Help me!¥" ¥"Cheryl!¥""); // 0x58e0: 0000100c
 HandleInput(); // 0x58e6: 00000010
 ShowText((1465)"I turn around and run back down the escalator toward the first floor hall. The image of Cheryl on the monitors then begins to get more and more fuzzy, until it dissolves into video static on the picture tube."); // 0x58ea: 0000100c
 HandleInput(); // 0x58f0: 00000010
@@ -4682,7 +4682,7 @@ ShowText((4092)"Sand is spread all over the open area inside, and it is lit by i
 HandleInput(); // 0x5cce: 00000010
 ShowText((4093)"There is a circular hole in one of the metal gratings that surrounds the area. From there I can enter the area."); // 0x5cd2: 0000100c
 HandleInput(); // 0x5cd8: 00000010
-ShowText((4094)"I bent down and stepped into the walled-off area. Upon moving in just a bit I find...a rifle."); // 0x5cdc: 0000100c
+ShowText((4094)"I bent down and stepped into the walled-off area. Upon moving in just a bit I find... a rifle."); // 0x5cdc: 0000100c
 HandleInput(); // 0x5ce2: 00000010
 Jump(L_0x59da); // 0x5ce6: 00001001
 L_0x5cec:
@@ -4706,7 +4706,7 @@ HandleInput(); // 0x5d58: 00000010
 PlaySecondSoundFx(0xf); // 0x5d5c: 00001073
 LoadSecondEffect(0xf, 0x1, 0x2); // 0x5d62: 0000306e
 LoadSecondEffect(0x0, 0x0, 0x2); // 0x5d6c: 0000306e
-ShowText((4099)"I pulled the trigger over and over until I ran out of bullets. As its screams echoed, the only that that kept me going as I was about to pass out was...... Cheryl's smiling face in my memories."); // 0x5d76: 0000100c
+ShowText((4099)"I pulled the trigger over and over until I ran out of bullets. As its screams echoed, the only that that kept me going as I was about to pass out was... Cheryl's smiling face in my memories."); // 0x5d76: 0000100c
 HandleInput(); // 0x5d7c: 00000010
 LoadSecondEffect(0x23, 0x0, 0x1); // 0x5d80: 0000306e
 LoadSecondEffect(0x0, 0x0, 0x1); // 0x5d8a: 0000306e
@@ -4748,7 +4748,7 @@ HandleInput(); // 0x5e6c: 00000010
 PlaySecondSoundFx(0xf); // 0x5e70: 00001073
 LoadSecondEffect(0xf, 0x1, 0x2); // 0x5e76: 0000306e
 LoadSecondEffect(0x0, 0x0, 0x2); // 0x5e80: 0000306e
-ShowText((4099)"I pulled the trigger over and over until I ran out of bullets. As its screams echoed, the only that that kept me going as I was about to pass out was...... Cheryl's smiling face in my memories."); // 0x5e8a: 0000100c
+ShowText((4099)"I pulled the trigger over and over until I ran out of bullets. As its screams echoed, the only that that kept me going as I was about to pass out was... Cheryl's smiling face in my memories."); // 0x5e8a: 0000100c
 HandleInput(); // 0x5e90: 00000010
 Jump(L_0xa976); // 0x5e94: 00001001
 L_0x5e9a:
@@ -4811,7 +4811,7 @@ ShowText((4110)"But I cannot find the hole in the fence that I just came through
 HandleInput(); // 0x5fe0: 00000010
 ShowText((4111)"I begin to run. However, it pursues me from under the ground with unthinkable speed. The tremors at my feet gradually get stronger and stronger."); // 0x5fe4: 0000100c
 HandleInput(); // 0x5fea: 00000010
-ShowText((4112)"I fling my self to a stop and notice a steel plate lying in front of me."); // 0x5fee: 0000100c
+ShowText((4112)"I fling myself to a stop and notice a steel plate lying in front of me."); // 0x5fee: 0000100c
 HandleInput(); // 0x5ff4: 00000010
 Jump(L_0xa93e); // 0x5ff8: 00001001
 L_0x5ffe:
@@ -4825,7 +4825,7 @@ OP_0x65(); // 0x6024: 00000065
 PlayMusic(0x68); // 0x6028: 0000106c
 ShowText((1485)"Perhaps the caterpillar from before was blocking my path to the hospital, as my route, which had been blocked until just before, was now restored."); // 0x602e: 0000100c
 HandleInput(); // 0x6034: 00000010
-ShowText((1486)"The entire town seemed like the insides of an enormous living thing. If a part of it is treated...then a part of it is destroyed. If a part of it disappears...then a part of it appears. I get the feeling that I am wandering about within a living organism that has become a labyrinth."); // 0x6038: 0000100c
+ShowText((1486)"The entire town seemed like the insides of an enormous living thing. If a part of it is treated... then a part of it is destroyed. If a part of it disappears... then a part of it appears. I get the feeling that I am wandering about within a living organism that has become a labyrinth."); // 0x6038: 0000100c
 HandleInput(); // 0x603e: 00000010
 CleanScreen(); // 0x6042: 00000064
 LoadBackground(0x69); // 0x6046: 00001069
@@ -4897,9 +4897,9 @@ LoadSecondEffect(0x33, 0x1, 0x1, 0x1); // 0x61aa: 0000406e
 ShowText((1499)"I speak. ¥"How about coming with me? This may not be the safest place in the world either. I can't promise you anything, but I'll do my best to protect you.¥""); // 0x61b6: 0000100c
 HandleInput(); // 0x61bc: 00000010
 LoadSecondEffect(0x33, 0x2, 0x1); // 0x61c0: 0000306e
-ShowText((1500)"¥"No...somehow I feel I'm not supposed to leave this place. Oh, Harry, I'm so scared... I'm cold.¥""); // 0x61ca: 0000100c
+ShowText((1500)"¥"No... somehow I feel I'm not supposed to leave this place. Oh, Harry, I'm so scared... I'm cold.¥""); // 0x61ca: 0000100c
 HandleInput(); // 0x61d0: 00000010
-ShowText((1501)"I waver. Is it ok for me to leave Lisa alone... But then, what will happen to Cheryl? Cheryl has only me to depend on. My concern for Cheryl cannot be compared with my concern for Lisa. After all...she is my daughter."); // 0x61d4: 0000100c
+ShowText((1501)"I waver. Is it okay for me to leave Lisa alone...? But then, what will happen to Cheryl? Cheryl has only me to depend on. My concern for Cheryl cannot be compared with my concern for Lisa. After all... she is my daughter."); // 0x61d4: 0000100c
 HandleInput(); // 0x61da: 00000010
 ShowText((1502)"¥"Look, just wait here a little longer. I'll be back as soon as I find my daughter.¥" Perhaps those words rang cold for Lisa. But there is nothing that can be done. I must save my daughter. ¥"Harry...¥""); // 0x61de: 0000100c
 HandleInput(); // 0x61e4: 00000010
@@ -4930,7 +4930,7 @@ LoadEffect(0x0, 0x0, 0x0); // 0x6270: 0000306d
 LoadBackground(0x8d); // 0x627a: 00001069
 OP_0x65(); // 0x6280: 00000065
 PlayMusic(0x66); // 0x6284: 0000106c
-ShowText((1505)"¥"What...what is this...?¥" A giant moth... I guess I didn't completely kill it. That caterpillar that I shot at the Town Center has followed me here."); // 0x628a: 0000100c
+ShowText((1505)"¥"What... What is this...?¥" A giant moth... I guess I didn't completely kill it. That caterpillar that I shot at the Town Center has followed me here."); // 0x628a: 0000100c
 HandleInput(); // 0x6290: 00000010
 CleanScreen(); // 0x6294: 00000064
 LoadBackground(0x0); // 0x6298: 00001069
@@ -5015,9 +5015,9 @@ LoadEffect(0x33, 0x1, 0x1, 0x2); // 0x6468: 0000406d
 OP_0x65(); // 0x6474: 00000065
 PlayMusic(0x71, 0x1); // 0x6478: 0000206c
 LoadSecondEffect(0x33, 0x1, 0x1, 0x1); // 0x6480: 0000406e
-ShowText((4113)"I waver. Is it ok for me to leave Lisa alone... But then, what will happen to Cheryl? Cheryl has only me to depend on. My concern for Cheryl cannot be compared with my concern for Lisa. And no matter what she is my daughter."); // 0x648c: 0000100c
+ShowText((4113)"I waver. Is it okay for me to leave Lisa alone...? But then, what will happen to Cheryl? Cheryl has only me to depend on. My concern for Cheryl cannot be compared with my concern for Lisa. And no matter what she is my daughter."); // 0x648c: 0000100c
 HandleInput(); // 0x6492: 00000010
-ShowText((4114)"¥"Look, just wait here a little longer. I'll be back as soon as I find my daughter.¥" Perhaps those words rang cold for Lisa. But there is nothing that can be done. I must save my daughter. ¥"Harry......¥""); // 0x6496: 0000100c
+ShowText((4114)"¥"Look, just wait here a little longer. I'll be back as soon as I find my daughter.¥" Perhaps those words rang cold for Lisa. But there is nothing that can be done. I must save my daughter. ¥"Harry...¥""); // 0x6496: 0000100c
 HandleInput(); // 0x649c: 00000010
 LoadSecondEffect(0x33, 0x0, 0x1); // 0x64a0: 0000306e
 LoadSecondEffect(0x0, 0x0, 0x1); // 0x64aa: 0000306e
@@ -5066,7 +5066,7 @@ HandleInput(); // 0x65b2: 00000010
 PlaySecondSoundFx(0xf); // 0x65b6: 00001073
 ShowText((4122)"The sound of my first shot reverberates into the night. But the bullet just grazes its head and disappears off into the darkness. ¥"Damn...!¥""); // 0x65bc: 0000100c
 HandleInput(); // 0x65c2: 00000010
-ShowText((4123)"But I do not give up. I must get closer to my opponent. ...But, if I draw it in then I must be ready. As doing so would be accompanied by danger."); // 0x65c6: 0000100c
+ShowText((4123)"But I do not give up. I must get closer to my opponent... But, if I draw it in then I must be ready. As doing so would be accompanied by danger."); // 0x65c6: 0000100c
 HandleInput(); // 0x65cc: 00000010
 PlaySecondSoundFx(0x2a); // 0x65d0: 00001073
 ShowText((4124)"I avoid a shower of poison. Fortunately the wind has begun to blow. To adjust its wings to the wind takes all of its strength, and it appears to be having a difficult time attacking me."); // 0x65d6: 0000100c
@@ -5114,9 +5114,9 @@ OP_0x65(); // 0x66d4: 00000065
 PlayMusic(0x68); // 0x66d8: 0000106c
 ShowText((1510)"After passing through the sewers connected to the water supply installation near the elementary school I came up in the most popular part of Silent Hill, the lakeside tourist spot."); // 0x66de: 0000100c
 HandleInput(); // 0x66e4: 00000010
-ShowText((1511)"However, in spite of this there is no reason to expect anyone to be here. The area is wrapped in darkness, and in a condition in which it would be impossible to even walk around without a flashlight."); // 0x66e8: 0000100c
+ShowText((1511)"However, in spite of this, there is no reason to expect anyone to be here. The area is wrapped in darkness, and in a condition in which it would be impossible to even walk around without a flashlight."); // 0x66e8: 0000100c
 HandleInput(); // 0x66ee: 00000010
-ShowText((1512)"First I decide to enter ¥"Annie's Bar¥", which lies on the road to the lake. As I approach the door I notice what sounds like a struggle coming from the other side."); // 0x66f2: 0000100c
+ShowText((1512)"First I decide to enter Annie's Bar, which lies on the road to the lake. As I approach the door I notice what sounds like a struggle coming from the other side."); // 0x66f2: 0000100c
 HandleInput(); // 0x66f8: 00000010
 OP_0x2c(0x3, 0x1); // 0x66fc: 0000202c
 Jump(L_0x670a); // 0x6704: 00001001
@@ -5130,7 +5130,7 @@ LoadBackground(0x8f); // 0x6728: 00001069
 LoadEffect(0x0, 0x0, 0x0); // 0x672e: 0000306d
 OP_0x65(); // 0x6738: 00000065
 PlayMusic(0x6f); // 0x673c: 0000106c
-ShowText((1513)"When I open the door, inside...Kaufmann is there. Doctor Michael Kaufmann, that is certainly what he said his name was. A monster has him cornered. His back is against the far wall of the bar and he is out of breath."); // 0x6742: 0000100c
+ShowText((1513)"When I open the door, inside... Kaufmann is there. Doctor Michael Kaufmann, that is certainly what he said his name was. A monster has him cornered. His back is against the far wall of the bar and he is out of breath."); // 0x6742: 0000100c
 HandleInput(); // 0x6748: 00000010
 OP_0x29(); // 0x674c: 00000029
 PlaySecondSoundFx(0xf); // 0x6750: 00001073
@@ -5199,7 +5199,7 @@ CleanScreen(); // 0x688c: 00000064
 LoadBackground(0x0); // 0x6890: 00001069
 OP_0x65(); // 0x6896: 00000065
 PlaySecondSoundFx(0xc); // 0x689a: 00001073
-ShowText((1523)"Doctor Michael Kaufmann, He definitely has some secret. While I am not sure whether it is connected to me rescuing Cheryl or not, he knows the main reason why this town has undergone a transformation."); // 0x68a0: 0000100c
+ShowText((1523)"Doctor Michael Kaufmann definitely has some secret. While I am not sure whether it is connected to me rescuing Cheryl or not, he knows the main reason why this town has undergone a transformation."); // 0x68a0: 0000100c
 HandleInput(); // 0x68a6: 00000010
 ShowText((1524)"I followed him so that he did not notice me."); // 0x68aa: 0000100c
 HandleInput(); // 0x68b0: 00000010
@@ -5287,7 +5287,7 @@ OP_0x65(); // 0x6a5e: 00000065
 PlayMusic(0x67, 0x1); // 0x6a62: 0000206c
 ShowText((4130)"¥"Do you know this girl?¥" His hand, which he had placed on the doorknob, paused for a moment. And then he looked back at me."); // 0x6a6a: 0000100c
 HandleInput(); // 0x6a70: 00000010
-ShowText((4131)"I hold the picture of Alessa in my hand. Upon seeing it a look of horror appears on Kaufmann's face and he freezes. ¥"You...just who in the hell are you...?¥""); // 0x6a74: 0000100c
+ShowText((4131)"I hold the picture of Alessa in my hand. Upon seeing it a look of horror appears on Kaufmann's face and he freezes. ¥"You... Just who in the hell are you...?¥""); // 0x6a74: 0000100c
 HandleInput(); // 0x6a7a: 00000010
 CleanScreen(); // 0x6a7e: 00000064
 LoadBackground(0x0); // 0x6a82: 00001069
@@ -5356,7 +5356,7 @@ ShowText((1554)"Little by little, the invasion is spreading... Trying to swallow
 HandleInput(); // 0x6bd6: 00000010
 ShowText((1555)"¥"Harry. Hold on a minute. I don't get it?¥" ¥"Look, I don't understand it all myself. I guess I can't explain it.¥" I honestly revealed how I felt."); // 0x6bda: 0000100c
 HandleInput(); // 0x6be0: 00000010
-ShowText((1556)"¥"Well, what's making this happen?¥" I don't know that either. But, I do know Cheryl is ¥"there¥".¥" ¥"There...?¥""); // 0x6be4: 0000100c
+ShowText((1556)"¥"Well, what's making this happen?¥" ¥"I don't know that either. But, I do know Cheryl is 'there'.¥" ¥"'There'...?¥""); // 0x6be4: 0000100c
 HandleInput(); // 0x6bea: 00000010
 ShowText((1557)"¥"Under whoever created this darkness. Cheryl is somewhere. And she needs my help.¥" Once I finished explaining everything Cybil faintly smiled, and looked at me as if she was worried."); // 0x6bee: 0000100c
 HandleInput(); // 0x6bf4: 00000010
@@ -5431,7 +5431,7 @@ OP_0x29(); // 0x6d86: 00000029
 PlaySecondSoundFx(0xc); // 0x6d8a: 00001073
 ShowText((1569)"¥"Cybil... Thanks.¥" Gripping her handgun, Cybil left the boat and disappeared into the darkness. ¥"You will need to use it.¥" ¥"Use what?¥" ¥"The Flauros. Only with that can you stop it.¥""); // 0x6d90: 0000100c
 HandleInput(); // 0x6d96: 00000010
-ShowText((1570)"Wait...the Flauros. I check inside my pockets. That four sided object. However, does Cybil have such an object as well?"); // 0x6d9a: 0000100c
+ShowText((1570)"Wait... The Flauros. I check inside my pockets. That four sided object. However, does Cybil have such an object as well?"); // 0x6d9a: 0000100c
 HandleInput(); // 0x6da0: 00000010
 ShowText((1571)"No, that is not likely. If she did, then she probably would have been able to understand my story a little better."); // 0x6da4: 0000100c
 HandleInput(); // 0x6daa: 00000010
@@ -5447,7 +5447,7 @@ LoadEffect(0x27, 0x2, 0x1, 0x2); // 0x6dd6: 0000406d
 OP_0x65(); // 0x6de2: 00000065
 PlayMusic(0x67, 0x1); // 0x6de6: 0000206c
 LoadSecondEffect(0x27, 0x2, 0x1, 0x1); // 0x6dee: 0000406e
-ShowText((4133)"As usual I pretended to go along with what Cybil is saying and nodded."); // 0x6dfa: 0000100c
+ShowText((4133)"As usual, I pretended to go along with what Cybil is saying and nodded."); // 0x6dfa: 0000100c
 HandleInput(); // 0x6e00: 00000010
 LoadSecondEffect(0x27, 0x0, 0x1); // 0x6e04: 0000306e
 LoadSecondEffect(0x0, 0x0, 0x1); // 0x6e0e: 0000306e
@@ -5577,12 +5577,12 @@ LoadBackground(0x0); // 0x708c: 00001069
 OP_0x65(); // 0x7092: 00000065
 ShowText((4140)"I was walking on air... With each step I took toward the distortion I was stepping on air."); // 0x7096: 0000100c
 HandleInput(); // 0x709c: 00000010
-ShowText((4141)"Finally my body is completely enveloped in that hole. Inside...Alessa was sitting on the ground sobbing."); // 0x70a0: 0000100c
+ShowText((4141)"Finally my body is completely enveloped in that hole. Inside... Alessa was sitting on the ground sobbing."); // 0x70a0: 0000100c
 HandleInput(); // 0x70a6: 00000010
 PlaySoundFx(0x39); // 0x70aa: 00001072
 ShowText((4142)"Alessa. Alessa covered her face with her hands, and her shoulders trembled as she cried. I nestled up to her and knelt down."); // 0x70b0: 0000100c
 HandleInput(); // 0x70b6: 00000010
-ShowText((4143)"Suddenly the area became a sea of fire. Among the heaps of debris Alessa is screaming. This is...what is in Alessa's mind. Alessa's suffering mind."); // 0x70ba: 0000100c
+ShowText((4143)"Suddenly the area became a sea of fire. Among the heaps of debris Alessa is screaming. This is... what is in Alessa's mind. Alessa's suffering mind."); // 0x70ba: 0000100c
 HandleInput(); // 0x70c0: 00000010
 ShowText((4144)"The detestable event of seven years ago... The flames that burned an entire section of the town... It was being replayed before my eyes."); // 0x70c4: 0000100c
 HandleInput(); // 0x70ca: 00000010
@@ -5601,7 +5601,7 @@ OP_0x65(); // 0x7108: 00000065
 PlayMusic(0x68); // 0x710c: 0000106c
 ShowText((4149)"Cold rain moistens my cheeks. When I come to I realize that I am standing frozen on top of the lighthouse, staring off into the empty darkness."); // 0x7112: 0000100c
 HandleInput(); // 0x7118: 00000010
-ShowText((4150)"A dream...? Was I hallucinating...? Oh...and what about Cheryl..."); // 0x711c: 0000100c
+ShowText((4150)"A dream...? Was I hallucinating...? Oh... And what about Cheryl...?"); // 0x711c: 0000100c
 HandleInput(); // 0x7122: 00000010
 Jump(L_0x6f66); // 0x7126: 00001001
 L_0x712c:
@@ -5611,7 +5611,7 @@ CleanScreen(); // 0x713a: 00000064
 LoadBackground(0xa0); // 0x713e: 00001069
 OP_0x65(); // 0x7144: 00000065
 PlayMusic(0x6f, 0x1); // 0x7148: 0000206c
-ShowText((4151)"Wait...I held myself back. I have a bad feeling about this. I think about Cheryl and then I cannot take any dangerous chances."); // 0x7150: 0000100c
+ShowText((4151)"Wait... I held myself back. I have a bad feeling about this. I think about Cheryl and then I cannot take any dangerous chances."); // 0x7150: 0000100c
 HandleInput(); // 0x7156: 00000010
 ShowText((4152)"And the safety of Cybil, who is working with me to look for Cheryl, concerns me as well..."); // 0x715a: 0000100c
 HandleInput(); // 0x7160: 00000010
@@ -5635,11 +5635,11 @@ ShowText((1582)"I pass by the Ferris wheel, and arrive at the merry-go-round. Ho
 HandleInput(); // 0x71b8: 00000010
 ShowText((1583)"While it is only natural for a ride to not be in operation, it seems unnatural for this merry-go-round to not be running... I walk around it."); // 0x71bc: 0000100c
 HandleInput(); // 0x71c2: 00000010
-ShowText((1584)"Clink...Clink... While slipping between the horses I look for Cybil. Quite a bit of time has passed since she came here."); // 0x71c6: 0000100c
+ShowText((1584)"Clink... Clink... While slipping between the horses I look for Cybil. Quite a bit of time has passed since she came here."); // 0x71c6: 0000100c
 HandleInput(); // 0x71cc: 00000010
 ShowText((1585)"I suppose maybe she didn't find Cheryl and headed back to that ship. But the only way to get here is through those sewers. If she had gone back then we should have ran across each other at some point."); // 0x71d0: 0000100c
 HandleInput(); // 0x71d6: 00000010
-ShowText((1586)"¥"Huh...what is this...?¥" I slowly kneel down and try touching it. The dark green liquid is still warm. Something moved through here, and if this trail is traced it will lead back to the source of the liquid."); // 0x71da: 0000100c
+ShowText((1586)"¥"Huh... What is this...?¥" I slowly kneel down and try touching it. The dark green liquid is still warm. Something moved through here, and if this trail is traced it will lead back to the source of the liquid."); // 0x71da: 0000100c
 HandleInput(); // 0x71e0: 00000010
 Jump(L_0x71ea); // 0x71e4: 00001001
 L_0x71ea:
@@ -5649,7 +5649,7 @@ CleanScreen(); // 0x71f8: 00000064
 LoadBackground(0xaa); // 0x71fc: 00001069
 OP_0x65(); // 0x7202: 00000065
 PlayMusic(0x68, 0x1); // 0x7206: 0000206c
-ShowText((1587)"And then...in the darkness I see Cybil from behind."); // 0x720e: 0000100c
+ShowText((1587)"And then... in the darkness I see Cybil from behind."); // 0x720e: 0000100c
 HandleInput(); // 0x7214: 00000010
 ShowText((1588)"¥"Cybil...¥" I try calling out to her. Only the low sound of the motor of the Ferris wheel echoes from afar. She should be able to hear me. I take another look at her."); // 0x7218: 0000100c
 HandleInput(); // 0x721e: 00000010
@@ -5673,7 +5673,7 @@ ShowText((1592)"And then, as if I am watching her in slow motion she raises her 
 HandleInput(); // 0x7280: 00000010
 LoadSecondEffect(0x39, 0x2, 0x1); // 0x7284: 0000306e
 PlaySecondSoundFx(0xf); // 0x728e: 00001073
-ShowText((1593)"¥"Cybil, it's me. It's Harry!¥" The bullet grazes my shoulder, and with a discordant metallic sound it hits one of the wooden horses. ...She is coming towards me."); // 0x7294: 0000100c
+ShowText((1593)"¥"Cybil, it's me. It's Harry!¥" The bullet grazes my shoulder, and with a discordant metallic sound it hits one of the wooden horses... She is coming towards me."); // 0x7294: 0000100c
 HandleInput(); // 0x729a: 00000010
 ShowText((1594)"Her eyes no longer appear to be human. The eerie red color of her eyes does not make it look like her life-force has been drained, but instead, it makes it appear as if she has been possessed by some evil being."); // 0x729e: 0000100c
 HandleInput(); // 0x72a4: 00000010
@@ -5681,7 +5681,7 @@ CleanScreen(); // 0x72a8: 00000064
 LoadBackground(0xaf); // 0x72ac: 00001069
 LoadEffect(0x0, 0x0, 0x1); // 0x72b2: 0000306d
 OP_0x65(); // 0x72bc: 00000065
-ShowText((1595)"I was too late, I think. Her heart had been devoured by someone, no by Alessa. What is there is no longer Cybil. Just an alter-ego of Alessa that is using Cybil's body..."); // 0x72c0: 0000100c
+ShowText((1595)"I was too late, I think. Her heart had been devoured by someone, no, by Alessa. What is there is no longer Cybil. Just an alter-ego of Alessa that is using Cybil's body..."); // 0x72c0: 0000100c
 HandleInput(); // 0x72c6: 00000010
 Jump(L_0x72d0); // 0x72ca: 00001001
 L_0x72d0:
@@ -5690,18 +5690,18 @@ Area(0xca); // 0x72d8: 00001026
 CleanScreen(); // 0x72de: 00000064
 LoadBackground(0xaf); // 0x72e2: 00001069
 OP_0x65(); // 0x72e8: 00000065
-ShowText((1596)"At that time I remembered. I searched my pockets...got it. The pet bottle. The vermilion liquid is inside it. I scooped it up in the hospital."); // 0x72ec: 0000100c
+ShowText((1596)"At that time I remembered. I searched my pockets... Got it. The plastic bottle. The vermilion liquid is inside it. I scooped it up in the hospital."); // 0x72ec: 0000100c
 HandleInput(); // 0x72f2: 00000010
-ShowText((1597)"The red of Cybil's eyes looked a lot like the red of that liquid. I hold up the pet bottle so that Cybil can see it and shake it left and right."); // 0x72f6: 0000100c
+ShowText((1597)"The red of Cybil's eyes looked a lot like the red of that liquid. I hold up the plastic bottle so that Cybil can see it and shake it left and right."); // 0x72f6: 0000100c
 HandleInput(); // 0x72fc: 00000010
 ShowText((1598)"And then just for a moment her expression changed to one of imploring... She must be aware. But she seems to be caught on an edge in her body, her body that will not do her bidding."); // 0x7300: 0000100c
 HandleInput(); // 0x7306: 00000010
 ShowText((1599)"It is like she is being attracted to me... With her gun ready, Cybil approaches. Upon closer inspection I can see that her eyes are full of tears."); // 0x730a: 0000100c
 HandleInput(); // 0x7310: 00000010
-ShowText((1600)"I unscrew the cap of the pet bottle. No one is riding the wooden horses, so their speed increases. I think that it is like time is rapidly passing for everything but the two of us."); // 0x7314: 0000100c
+ShowText((1600)"I unscrew the cap of the plastic bottle. No one is riding the wooden horses, so their speed increases. I think that it is like time is rapidly passing for everything but the two of us."); // 0x7314: 0000100c
 HandleInput(); // 0x731a: 00000010
 PlaySecondSoundFx(0x2a); // 0x731e: 00001073
-ShowText((1601)"At the same time as the hammer falls in Cybil's gun with a 'click' I sprinkle the liquid in the pet bottle on Cybil without leaving a drop inside."); // 0x7324: 0000100c
+ShowText((1601)"At the same time as the hammer falls in Cybil's gun with a 'click' I sprinkle the liquid in the plastic bottle on Cybil without leaving a drop inside."); // 0x7324: 0000100c
 HandleInput(); // 0x732a: 00000010
 LoadSecondEffect(0x11, 0x1, 0x2); // 0x732e: 0000306e
 WaitTime(0x78); // 0x7338: 0000101f
@@ -5722,9 +5722,9 @@ LoadBackground(0xa7); // 0x7382: 00001069
 OP_0x65(); // 0x7388: 00000065
 PlayMusic(0x71); // 0x738c: 0000106c
 LoadSecondEffect(0x28, 0x1, 0x1); // 0x7392: 0000306e
-ShowText((1605)"¥"Cybil! Wake up! Snap out of it!¥" Cybil doesn't respond. ¥"Cybil!¥" ........................ After a bit Cybil opened her eyes. Her eyes are a calm blue."); // 0x739c: 0000100c
+ShowText((1605)"¥"Cybil! Wake up! Snap out of it!¥" Cybil doesn't respond. ¥"Cybil!¥" ........................ After a bit, Cybil opened her eyes. Her eyes are a calm blue."); // 0x739c: 0000100c
 HandleInput(); // 0x73a2: 00000010
-ShowText((1606)"¥"...Harry? ...What...happened?¥" ¥"Shh...Don't talk. I'll take care of you.¥" A look of relief appears on her face and then she closes her eyes again."); // 0x73a6: 0000100c
+ShowText((1606)"¥"...Harry? ...What...happened?¥" ¥"Shh... Don't talk. I'll take care of you.¥" A look of relief appears on her face and then she closes her eyes again."); // 0x73a6: 0000100c
 HandleInput(); // 0x73ac: 00000010
 ShowText((1607)"Once I am done binding her wound, I close my eyes as well, and place my hand on Cybil's shoulder."); // 0x73b0: 0000100c
 HandleInput(); // 0x73b6: 00000010
@@ -5775,7 +5775,7 @@ HandleInput(); // 0x749e: 00000010
 PlaySecondSoundFx(0x2d); // 0x74a2: 00001073
 ShowText((1623)"And then she brings her arm down and my entire body is blown backwards. My body tumbles across the ground like a rag for about 30 meters, and then finally comes to a rest."); // 0x74a8: 0000100c
 HandleInput(); // 0x74ae: 00000010
-ShowText((1624)"¥"Damn!¥" Such incredible power. A servant of god, a demon's power. A normal person like me has no chance against her. Power is gushing out of her body, and it emits a pale light. I cannot even approach her."); // 0x74b2: 0000100c
+ShowText((1624)"¥"Damn!¥" Such incredible power. A servant of God, a demon's power. A normal person like me has no chance against her. Power is gushing out of her body, and it emits a pale light. I cannot even approach her."); // 0x74b2: 0000100c
 HandleInput(); // 0x74b8: 00000010
 LoadSecondEffect(0x2a, 0x1, 0x1); // 0x74bc: 0000306e
 OP_0x2c(0x3, 0x1); // 0x74c6: 0000202c
@@ -5799,7 +5799,7 @@ HandleInput(); // 0x752a: 00000010
 OP_0x2c(0x2, 0x1); // 0x752e: 0000202c
 PlayMusic(0x67); // 0x7536: 0000106c
 LoadSecondEffect(0x2b, 0x2, 0x2); // 0x753c: 0000306e
-ShowText((1630)"¥"We meet at last, Alessa.¥" ¥"......!¥" ¥"Dahli. Gillespie......¥""); // 0x7546: 0000100c
+ShowText((1630)"¥"We meet at last, Alessa.¥" ¥"...!¥" ¥"Dahlia Gillespie...¥""); // 0x7546: 0000100c
 HandleInput(); // 0x754c: 00000010
 ShowText((1631)"Unable to move from my prone position I thought about who's voice that was. And then using all my strength I stand. After confirming that it was Dahlia in front of me I spoke in a voice that was nearly a yell."); // 0x7550: 0000100c
 HandleInput(); // 0x7556: 00000010
@@ -5807,7 +5807,7 @@ ShowText((1632)"¥"Where's Cheryl? Where is she?¥""); // 0x755a: 0000100c
 HandleInput(); // 0x7560: 00000010
 ShowText((1633)"Dahlia does not hear me yelling. She does not look back, and looks at Alessa with a creepy smile."); // 0x7564: 0000100c
 HandleInput(); // 0x756a: 00000010
-ShowText((1634)"¥"Alessa. This is the end of your little game.¥" ¥"Mama...¥" Mother...? I am confused. ¥"Huh? Could she be...?¥""); // 0x756e: 0000100c
+ShowText((1634)"¥"Alessa. This is the end of your little game.¥" ¥"Mama...¥" 'Mama'...? I am confused. ¥"Huh? Could she be...?¥""); // 0x756e: 0000100c
 HandleInput(); // 0x7574: 00000010
 ShowText((1635)"¥"You've been a ghastly little pest, haven't you? Alessa? I was careless. Thinking you couldn't escape from our spell."); // 0x7578: 0000100c
 HandleInput(); // 0x757e: 00000010
@@ -5825,35 +5825,35 @@ LoadBackground(0xa6); // 0x75b2: 00001069
 LoadEffect(0x0, 0x0, 0x1); // 0x75b8: 0000306d
 OP_0x65(); // 0x75c2: 00000065
 PlayMusic(0x67, 0x1); // 0x75c6: 0000206c
-ShowText((1641)"Lisa? What happened? Where's Alessa and Dahlia?"); // 0x75ce: 0000100c
+ShowText((1641)"¥"Lisa? What happened? Where's Alessa and Dahlia?¥""); // 0x75ce: 0000100c
 HandleInput(); // 0x75d4: 00000010
-ShowText((1642)"Harry, listen. Something you said before has been bothering me. I just can't get it out of my head."); // 0x75d8: 0000100c
+ShowText((1642)"¥"Harry, listen. Something you said before has been bothering me. I just can't get it out of my head.¥""); // 0x75d8: 0000100c
 HandleInput(); // 0x75de: 00000010
-ShowText((1643)"What is it Lisa?"); // 0x75e2: 0000100c
+ShowText((1643)"¥"What is it Lisa?¥""); // 0x75e2: 0000100c
 HandleInput(); // 0x75e8: 00000010
-ShowText((1644)"So I went to look in the basement. Even though I was scared as hell. Like you said, there were these creepy rooms."); // 0x75ec: 0000100c
+ShowText((1644)"¥"So I went to look in the basement. Even though I was scared as hell. Like you said, there were these creepy rooms."); // 0x75ec: 0000100c
 HandleInput(); // 0x75f2: 00000010
 ShowText((1645)"But nothing really unusual down there. But while I was down there, I got this weird feeling. Like I'd been there before."); // 0x75f6: 0000100c
 HandleInput(); // 0x75fc: 00000010
-ShowText((1646)"Like something happened there, but I can't quite remember somehow. What was it? Harry... help me... I'm so scared. I can't take this."); // 0x7600: 0000100c
+ShowText((1646)"Like something happened there, but I can't quite remember somehow. What was it? Harry... help me... I'm so scared. I can't take this.¥""); // 0x7600: 0000100c
 HandleInput(); // 0x7606: 00000010
-ShowText((1647)"It's only a temporary thing. You're in shock from when you were knocked out. Don't fret about it, you'll remember after a while..."); // 0x760a: 0000100c
+ShowText((1647)"¥"It's only a temporary thing. You're in shock from when you were knocked out. Don't fret about it, you'll remember after a while...¥""); // 0x760a: 0000100c
 HandleInput(); // 0x7610: 00000010
-ShowText((1648)"No. You don't understand..."); // 0x7614: 0000100c
+ShowText((1648)"¥"No. You don't understand...¥""); // 0x7614: 0000100c
 HandleInput(); // 0x761a: 00000010
-ShowText((1649)"Wait! Where do you think you're going?"); // 0x761e: 0000100c
+ShowText((1649)"¥"Wait! Where do you think you're going?¥""); // 0x761e: 0000100c
 HandleInput(); // 0x7624: 00000010
 ShowText((1650)"......................................................................"); // 0x7628: 0000100c
 HandleInput(); // 0x762e: 00000010
-ShowText((1651)"Harry?"); // 0x7632: 0000100c
+ShowText((1651)"¥"Harry?¥""); // 0x7632: 0000100c
 HandleInput(); // 0x7638: 00000010
-ShowText((1652)"Lisa... What's the matter with you?"); // 0x763c: 0000100c
+ShowText((1652)"¥"Lisa... What's the matter with you?¥""); // 0x763c: 0000100c
 HandleInput(); // 0x7642: 00000010
-ShowText((1653)"I get it now... Why I'm still alive even though everyone else is dead. I'm not the only one who's still walking around. I'm the same as them. I just hadn't noticed it before."); // 0x7646: 0000100c
+ShowText((1653)"¥"I get it now... Why I'm still alive even though everyone else is dead. I'm not the only one who's still walking around. I'm the same as them. I just hadn't noticed it before.¥""); // 0x7646: 0000100c
 HandleInput(); // 0x764c: 00000010
-ShowText((1654)"Lisa?"); // 0x7650: 0000100c
+ShowText((1654)"¥"Lisa?¥""); // 0x7650: 0000100c
 HandleInput(); // 0x7656: 00000010
-ShowText((1655)"Stay by me, Harry. Please. I'm so scared. Help me... Save me from them. Please... Harry..."); // 0x765a: 0000100c
+ShowText((1655)"¥"Stay by me, Harry. Please. I'm so scared. Help me... Save me from them. Please... Harry...¥""); // 0x765a: 0000100c
 HandleInput(); // 0x7660: 00000010
 Jump(L_0x766a); // 0x7664: 00001001
 L_0x766a:
@@ -5863,7 +5863,7 @@ CleanScreen(); // 0x7678: 00000064
 LoadBackground(0xa6); // 0x767c: 00001069
 OP_0x65(); // 0x7682: 00000065
 PlayMusic(0x67, 0x1); // 0x7686: 0000206c
-Choice((350)"Lisa...", (351)"A ) Sorry...I cannot stay with you.", (352)"B ) Don't worry. I will do what I can."); // 0x768e: 00003011
+Choice((350)"Lisa...", (351)"A ) Sorry... I cannot stay with you.", (352)"B ) Don't worry. I will do what I can."); // 0x768e: 00003011
 Branch4(0x774, L_0x76a4); // 0x7698: 00001004
 Jump(L_0x76b8); // 0x769e: 00001001
 L_0x76a4:
@@ -5885,7 +5885,7 @@ ShowText((1657)"I thought for a bit and came to a conclusion. ¥"...I cannot do 
 HandleInput(); // 0x76ec: 00000010
 ShowText((1658)"¥"That girl that you don't even know if is alive or not, you don't even know where she is now. You should be worried about the person that is alive right in front of you!¥""); // 0x76f0: 0000100c
 HandleInput(); // 0x76f6: 00000010
-ShowText((1659)"I lightly exhaled. ¥"No mater what you say, I must go... Please understand what I am going through. ...please.¥""); // 0x76fa: 0000100c
+ShowText((1659)"I lightly exhaled. ¥"No matter what you say, I must go... Please understand what I am going through. ...please.¥""); // 0x76fa: 0000100c
 HandleInput(); // 0x7700: 00000010
 ShowText((1660)"Saying that I turned toward the door. Lisa reached out to my shoulder. But I did not look back."); // 0x7704: 0000100c
 HandleInput(); // 0x770a: 00000010
@@ -5900,14 +5900,14 @@ OP_0x65(); // 0x7734: 00000065
 PlayMusic(0x65); // 0x7738: 0000106c
 ShowText((1661)"Lisa's condition becomes abnormal."); // 0x773e: 0000100c
 HandleInput(); // 0x7744: 00000010
-ShowText((1662)"She then extends her hand out towards me. ¥"Help me¥" She doesn't say it, but I know that is what she is saying from the movement of her lips."); // 0x7748: 0000100c
+ShowText((1662)"She then extends her hand out towards me. ¥"Help me.¥" She doesn't say it, but I know that is what she is saying from the movement of her lips."); // 0x7748: 0000100c
 HandleInput(); // 0x774e: 00000010
 CleanScreen(); // 0x7752: 00000064
 LoadBackground(0xb1); // 0x7756: 00001069
 OP_0x65(); // 0x775c: 00000065
 ShowText((1663)"While she stares into the air, Lisa's body appears to drift and wiggle as she edges toward me one step at a time."); // 0x7760: 0000100c
 HandleInput(); // 0x7766: 00000010
-ShowText((1664)"She falls to her knees. She falls on her hands. With me fixed in her sight, Lisa is falling headlong down the staircase to death. And then Lisa...stopped moving."); // 0x776a: 0000100c
+ShowText((1664)"She falls to her knees. She falls on her hands. With me fixed in her sight, Lisa is falling headlong down the staircase to death. And then Lisa... stopped moving."); // 0x776a: 0000100c
 HandleInput(); // 0x7770: 00000010
 CleanScreen(); // 0x7774: 00000064
 LoadBackground(0x0); // 0x7778: 00001069
@@ -5920,9 +5920,9 @@ PlaySoundFx(0x39); // 0x779a: 00001072
 WaitTime(0x3c); // 0x77a0: 0000101f
 ShowText((1666)"¥"Ask the doctor to let me quit being in charge of that patient. It's too weird. The room is filled with insects. Even with doors and windows shut they get in to spite me."); // 0x77a6: 0000100c
 HandleInput(); // 0x77ac: 00000010
-ShowText((1667)"To the hospital...... Still alive, but with wounds that won't heal Blood and pus flow from the bathroom faucet. I try to stop it but it won't turn off. Feeling bad. Need to throw up."); // 0x77b0: 0000100c
+ShowText((1667)"To the hospital... Still alive, but with wounds that won't heal Blood and pus flow from the bathroom faucet. I try to stop it but it won't turn off. Feeling bad. Need to throw up."); // 0x77b0: 0000100c
 HandleInput(); // 0x77b6: 00000010
-ShowText((1668)"But nothing comes out. Vomiting only bile. Need drug. Told the doctor I quit. Won't work at that hospital anymore. Someone, help me......¥""); // 0x77ba: 0000100c
+ShowText((1668)"But nothing comes out. Vomiting only bile. Need drug. Told the doctor I quit. Won't work at that hospital anymore. Someone, help me...¥""); // 0x77ba: 0000100c
 HandleInput(); // 0x77c0: 00000010
 Jump(L_0x7812); // 0x77c4: 00001001
 L_0x77ca:
@@ -5936,7 +5936,7 @@ ShowText((4154)"¥"Don't worry. I will do what I can.¥" A quiet smile appeared 
 HandleInput(); // 0x77f4: 00000010
 ShowText((4155)"I'm happy..."); // 0x77f8: 0000100c
 HandleInput(); // 0x77fe: 00000010
-ShowText((4156)"Lisa's body quivered. However, maybe that is just because she is relieved. She...looks at me with empty eyes, eyes that have lost their life. Then her lips began to tremble and a look of astonishment appears on her face."); // 0x7802: 0000100c
+ShowText((4156)"Lisa's body quivered. However, maybe that is just because she is relieved. She... looks at me with empty eyes, eyes that have lost their life. Then her lips began to tremble and a look of astonishment appears on her face."); // 0x7802: 0000100c
 HandleInput(); // 0x7808: 00000010
 Jump(L_0x7714); // 0x780c: 00001001
 L_0x7812:
@@ -5951,7 +5951,7 @@ OP_0x65(); // 0x783c: 00000065
 PlaySoundFx(0xd); // 0x7840: 00001072
 ShowText((1671)"The pocket radio continues to make noise. The raging of the unknown things around me rocks my eardrums. Those monsters, which always approach shortly after I use my flashlight... It was all I could do to intimidate them with the gun while running away."); // 0x7846: 0000100c
 HandleInput(); // 0x784c: 00000010
-ShowText((1672)"After running for a bit I realize that I am no longer in the original hospital. I have no way of knowing where here is."); // 0x7850: 0000100c
+ShowText((1672)"After running for a bit I realize that I am no longer in the original hospital. I have no way of knowing where I am."); // 0x7850: 0000100c
 HandleInput(); // 0x7856: 00000010
 ShowText((1673)"Bridging the gap of my faint consciousness, I move from place to place, I am being moved by someone... Maybe that is the best way to think about it."); // 0x785a: 0000100c
 HandleInput(); // 0x7860: 00000010
@@ -6016,7 +6016,7 @@ PlaySecondSoundFx(0x25); // 0x7984: 00001073
 CleanScreen(); // 0x798a: 00000064
 LoadBackground(0xb6); // 0x798e: 00001069
 OP_0x65(); // 0x7994: 00000065
-ShowText((1688)"I was forced down. I found that I had been thrown into a room of the hospital again. My body had rubbed on the disgustingly dirty floor. I picked my self up, and suppressed the urge to vomit while brushing off my shirt several times."); // 0x7998: 0000100c
+ShowText((1688)"I was forced down. I found that I had been thrown into a room of the hospital again. My body had rubbed on the disgustingly dirty floor. I picked myself up, and suppressed the urge to vomit while brushing off my shirt several times."); // 0x7998: 0000100c
 HandleInput(); // 0x799e: 00000010
 ShowText((1689)"A videocassette recorder has been installed here, and it looks like it can be used. I insert the tape that I had picked up at some point into it, and timidly press the play button."); // 0x79a2: 0000100c
 HandleInput(); // 0x79a8: 00000010
@@ -6024,18 +6024,18 @@ PlaySoundFx(0x27); // 0x79ac: 00001072
 LoadSecondEffect(0x3a, 0x1, 0x1); // 0x79b2: 0000306e
 ShowText((1690)"After a moment of static a picture appears. On the screen Lisa appears. She is sitting alone with her elbows on a desk and her head down. I turn up the volume on the monitor and listen carefully."); // 0x79bc: 0000100c
 HandleInput(); // 0x79c2: 00000010
-ShowText((1691)"(What is it? Still has an unusually high fever... Eyes don't open... Getting a pulse... But just barely breathing"); // 0x79c6: 0000100c
+ShowText((1691)"(What is it? Still has an unusually high fever... Eyes don't open... Getting a pulse... But just barely breathing..."); // 0x79c6: 0000100c
 HandleInput(); // 0x79cc: 00000010
 ShowText((1692)"Her skin is all charred! Even when I change the bandages, the blood and puss just start oozing through! Why... What is keeping that child alive?"); // 0x79d0: 0000100c
 HandleInput(); // 0x79d6: 00000010
-ShowText((1693)"I... can't stand it any longer... I won't tell a soul ...promise. So please...)"); // 0x79da: 0000100c
+ShowText((1693)"I... can't stand it any longer... I won't tell a soul... Promise. So please...)"); // 0x79da: 0000100c
 HandleInput(); // 0x79e0: 00000010
 OP_0x2c(0x2, 0x1); // 0x79e4: 0000202c
 LoadSecondEffect(0x0, 0x0, 0x1); // 0x79ec: 0000306e
 CleanScreen(); // 0x79f6: 00000064
 LoadBackground(0x0); // 0x79fa: 00001069
 OP_0x65(); // 0x7a00: 00000065
-ShowText((1694)"And then the screen goes black. The tape was ejected as if it were something dirty being spit out. It fell to the floor and it broke with a crash. Magnetic tape"); // 0x7a04: 0000100c
+ShowText((1694)"And then the screen goes black. The tape was ejected as if it were something dirty being spit out. It fell to the floor and it broke with a crash."); // 0x7a04: 0000100c
 HandleInput(); // 0x7a0a: 00000010
 Jump(L_0x7a14); // 0x7a0e: 00001001
 L_0x7a14:
@@ -6056,11 +6056,11 @@ OP_0x65(); // 0x7a5c: 00000065
 PlaySoundFx(0x39); // 0x7a60: 00001072
 ShowText((1697)"They are standing around a bed, with Dahlia on the left, Kaufmann on the right, and just a bit away from him some people in white coats that looks like a doctors. Each of them has troubled looks on their faces, and they peer at the face of the person lying on the bed."); // 0x7a66: 0000100c
 HandleInput(); // 0x7a6c: 00000010
-ShowText((1698)"(Everything is going according to plan. Sheltered in the womb.) (Dahlia) (But it's not done yet. Half the soul is lost. That is why the seed lies dormant.) (Man 1) (And what soul remains captured in that husk, is buried deep down in the subconscious) (Man 2)"); // 0x7a70: 0000100c
+ShowText((1698)"(Everything is going according to plan. Sheltered in the womb.) (Dahlia) (But it's not done yet. Half the soul is lost. That is why the seed lies dormant.) (Man 1) (And what soul remains captured in that husk, is buried deep down in the subconscious.) (Man 2)"); // 0x7a70: 0000100c
 HandleInput(); // 0x7a76: 00000010
 ShowText((1699)"(Are you trying to say it won't work!? That wasn't our agreement!) (Kaufmann)"); // 0x7a7a: 0000100c
 HandleInput(); // 0x7a80: 00000010
-ShowText((1700)"(No, no. These are just stalling tactics.) If we lend a hand, we will be able to get power. Never fear. The promise shall not be broken.) (Dahlia)"); // 0x7a84: 0000100c
+ShowText((1700)"(No, no. These are just stalling tactics. If we lend a hand, we will be able to get power. Never fear. The promise shall not be broken.) (Dahlia)"); // 0x7a84: 0000100c
 HandleInput(); // 0x7a8a: 00000010
 ShowText((1701)"(But the power we can draw now will be very weak; almost nothing. Unless we get the other half of the soul...) (Man 1)"); // 0x7a8e: 0000100c
 HandleInput(); // 0x7a94: 00000010
@@ -6117,13 +6117,13 @@ ShowText((1710)"This is a child's room. Stuffed animals and art supplies are sca
 HandleInput(); // 0x7b96: 00000010
 ShowText((9903)"Alessa probably collected these. Butterfly specimens of many different colors are on display."); // 0x7b9a: 0000100c
 HandleInput(); // 0x7ba0: 00000010
-ShowText((9904)"¥"...Huh...?¥" I think I just saw something flash."); // 0x7ba4: 0000100c
+ShowText((9904)"¥"Huh...?¥" I think I just saw something flash."); // 0x7ba4: 0000100c
 HandleInput(); // 0x7baa: 00000010
 Puzzle(0x3); // 0x7bae: 00001061
 CleanScreen(); // 0x7bb4: 00000064
 LoadBackground(0x191); // 0x7bb8: 00001069
 OP_0x65(); // 0x7bbe: 00000065
-ShowText((9916)"...I found a key... This key invites me... Had I not been very careful I would not have found it, as it was hidden behind one of the butterflies."); // 0x7bc2: 0000100c
+ShowText((9916)"I found a key... This key invites me... Had I not been very careful I would not have found it, as it was hidden behind one of the butterflies."); // 0x7bc2: 0000100c
 HandleInput(); // 0x7bc8: 00000010
 ShowText((1711)"There is a door in front of me. As I approach it, it seems to edge up to me. As I extend my hand to the knob the door makes a light tapping sound, and begins opening, as if inviting me into the heart of something evil."); // 0x7bcc: 0000100c
 HandleInput(); // 0x7bd2: 00000010
@@ -6157,7 +6157,7 @@ LoadBackground(0xc8); // 0x7c54: 00001069
 OP_0x65(); // 0x7c5a: 00000065
 ShowText((1716)"Dahlia and Alessa. It is definitely those two."); // 0x7c5e: 0000100c
 HandleInput(); // 0x7c64: 00000010
-ShowText((1717)"¥"I was shocked to realize the talisman of Metraton was being used. In spite of the lost soul returning at last. Just a little longer and all would have been for naught."); // 0x7c68: 0000100c
+ShowText((1717)"¥"I was shocked to realize the talisman of Metatron was being used. In spite of the lost soul returning at last. Just a little longer and all would have been for naught."); // 0x7c68: 0000100c
 HandleInput(); // 0x7c6e: 00000010
 ShowText((1718)"It's all because of that man. We must be thankful to him. Even though Alessa has been stopped, his little girl has to go. What a pity...¥""); // 0x7c72: 0000100c
 HandleInput(); // 0x7c78: 00000010
@@ -6174,7 +6174,7 @@ ShowText((1723)"¥"Stop this! Dahlia!¥" Dahlia shows no compunction or surprise
 HandleInput(); // 0x7cb0: 00000010
 ShowText((1724)"¥"Well, well, well. To think you'd make it this far.¥" ¥"Where's Cheryl!? What have you done to her!?¥""); // 0x7cb4: 0000100c
 HandleInput(); // 0x7cba: 00000010
-ShowText((1725)"¥"What are you talking about? You've seen her many times? Restored to her former self.¥" ¥"I'm in no mood for jokes.¥" I didn't understand what she was saying."); // 0x7cbe: 0000100c
+ShowText((1725)"¥"What are you talking about? You've seen her many times. Restored to her former self.¥" ¥"I'm in no mood for jokes.¥" I didn't understand what she was saying."); // 0x7cbe: 0000100c
 HandleInput(); // 0x7cc4: 00000010
 ShowText((1726)"¥"Don't you see? She's right there.¥" Right there? Only Alessa, draped in her blue clothing, is where Dahlia is pointing."); // 0x7cc8: 0000100c
 HandleInput(); // 0x7cce: 00000010
@@ -6244,7 +6244,7 @@ LoadEffect(0x0, 0x0, 0x1); // 0x7e1c: 0000306d
 OP_0x65(); // 0x7e26: 00000065
 ShowText((1742)"It has large wings and a head like a bull, and with its green muscles swelling it rose up and out of its mother's body, Alessa. And then it let out an earthshakingly brutal evil cry, and looked down at us."); // 0x7e2a: 0000100c
 HandleInput(); // 0x7e30: 00000010
-ShowText((1743)"¥"Huh? What the!?¥" I yell out, not addressing anyone in particular. ¥"What on earth? That's not supposed to...¥" Kaufmann just stands there in utter amazement, as the events unfold unlike how he had expected."); // 0x7e34: 0000100c
+ShowText((1743)"¥"Huh? What the!?¥" I yell out, not addressing anyone in particular. ¥"What on Earth? That's not supposed to...¥" Kaufmann just stands there in utter amazement, as the events unfold unlike how he had expected."); // 0x7e34: 0000100c
 HandleInput(); // 0x7e3a: 00000010
 ShowText((1744)"¥"It's awakening! It's awake! Now no one can interfere!¥" Dahlia, in a fit of insanity, had a feeling that could not be described as pleasant or angry."); // 0x7e3e: 0000100c
 HandleInput(); // 0x7e44: 00000010
@@ -6266,7 +6266,7 @@ ShowText((1749)"Cheryl is already beginning to run away from me."); // 0x7e9c: 0
 HandleInput(); // 0x7ea2: 00000010
 ShowText((1750)"¥"This can't be happening? Cheryl! Cheryl!?¥" I yell out. The figure of my daughter, who I have been searching for, gradually dissolves into the darkness just like the figure I saw when I first arrived in Silent Hill."); // 0x7ea6: 0000100c
 HandleInput(); // 0x7eac: 00000010
-ShowText((1751)"¥"Cheryl!! Wait......¥""); // 0x7eb0: 0000100c
+ShowText((1751)"¥"Cheryl!! Wait...¥""); // 0x7eb0: 0000100c
 HandleInput(); // 0x7eb6: 00000010
 CleanScreen(); // 0x7eba: 00000064
 LoadBackground(0x0); // 0x7ebe: 00001069
@@ -6278,7 +6278,7 @@ LoadSecondEffect(0x2d, 0x2, 0x2); // 0x7ede: 0000306e
 WaitTime(0x64); // 0x7ee8: 0000101f
 LoadSecondEffect(0x0, 0x0, 0x2); // 0x7eee: 0000306e
 PlayMusic(0x72); // 0x7ef8: 0000106c
-ShowText((1752)"Then electricity overflowed from the entire body of the creature that was born from Alessa. It divided into several lighting bolts, which struck above my head."); // 0x7efe: 0000100c
+ShowText((1752)"Then electricity overflowed from the entire body of the creature that was born from Alessa. It divided into several lightning bolts, which struck above my head."); // 0x7efe: 0000100c
 HandleInput(); // 0x7f04: 00000010
 ShowText((1753)"I run about trying to escape. However, that band of electricity follows me, and constantly appears in front of me."); // 0x7f08: 0000100c
 HandleInput(); // 0x7f0e: 00000010
@@ -6294,7 +6294,7 @@ LoadSecondEffect(0x2d, 0x2, 0x2); // 0x7f3e: 0000306e
 WaitTime(0x64); // 0x7f48: 0000101f
 LoadSecondEffect(0x0, 0x0, 0x2); // 0x7f4e: 0000306e
 OP_0x2a(0xe); // 0x7f58: 0000102a
-ShowText((1756)"I ready my weapon. During the short time between the lighting strikes I fire many bullets into the creature's body."); // 0x7f5e: 0000100c
+ShowText((1756)"I ready my weapon. During the short time between the lightning strikes I fire many bullets into the creature's body."); // 0x7f5e: 0000100c
 HandleInput(); // 0x7f64: 00000010
 PlaySecondSoundFx(0xf); // 0x7f68: 00001073
 LoadSecondEffect(0xf, 0x1, 0x2); // 0x7f6e: 0000306e
@@ -6348,7 +6348,7 @@ CleanScreen(); // 0x8082: 00000064
 LoadBackground(0xcb); // 0x8086: 00001069
 OP_0x65(); // 0x808c: 00000065
 PlaySoundFx(0x39); // 0x8090: 00001072
-ShowText((1772)"The great fireball, which was more that enough to completely burn both our bodies stopped just above Cybil, as she stood holding her head in her hands."); // 0x8096: 0000100c
+ShowText((1772)"The great fireball, which was more than enough to completely burn both our bodies stopped just above Cybil, as she stood holding her head in her hands."); // 0x8096: 0000100c
 HandleInput(); // 0x809c: 00000010
 ShowText((1773)"Time has stopped."); // 0x80a0: 0000100c
 HandleInput(); // 0x80a6: 00000010
@@ -6409,11 +6409,11 @@ ShowText((2002)"I pass by the Ferris wheel, and arrive at the merry-go-round. Bu
 HandleInput(); // 0x81c2: 00000010
 ShowText((2003)"While it is only natural for a ride to not be in operation, it seems unnatural for this merry-go-round to not be running... I walk around it."); // 0x81c6: 0000100c
 HandleInput(); // 0x81cc: 00000010
-ShowText((2004)"Clink...Clink... While slipping between the horses I look for Cybil. Quite a bit of time has passed since she came here."); // 0x81d0: 0000100c
+ShowText((2004)"Clink... Clink... While slipping between the horses I look for Cybil. Quite a bit of time has passed since she came here."); // 0x81d0: 0000100c
 HandleInput(); // 0x81d6: 00000010
 ShowText((2005)"I suppose maybe she didn't find Cheryl and headed back to that ship. But the only way to get here is through those sewers. If she had gone back then we should have ran across each other at some point."); // 0x81da: 0000100c
 HandleInput(); // 0x81e0: 00000010
-ShowText((2006)"¥"Huh...what is this...?¥" I slowly kneel down and try touching it. The dark green liquid is still warm. Something moved through here, and if this trail is traced it will lead back to the source of the liquid."); // 0x81e4: 0000100c
+ShowText((2006)"¥"Huh... What is this...?¥" I slowly kneel down and try touching it. The dark green liquid is still warm. Something moved through here, and if this trail is traced it will lead back to the source of the liquid."); // 0x81e4: 0000100c
 HandleInput(); // 0x81ea: 00000010
 Jump(L_0x81f4); // 0x81ee: 00001001
 L_0x81f4:
@@ -6423,7 +6423,7 @@ CleanScreen(); // 0x8202: 00000064
 LoadBackground(0xaa); // 0x8206: 00001069
 OP_0x65(); // 0x820c: 00000065
 PlayMusic(0x68, 0x1); // 0x8210: 0000206c
-ShowText((2007)"And then...in the darkness I see Cybil from behind."); // 0x8218: 0000100c
+ShowText((2007)"And then... in the darkness I see Cybil from behind."); // 0x8218: 0000100c
 HandleInput(); // 0x821e: 00000010
 ShowText((2008)"¥"Cybil...¥" I try calling out to her. Only the low sound of the motor of the Ferris wheel echoes from afar. She should be able to hear me. I take another look at her."); // 0x8222: 0000100c
 HandleInput(); // 0x8228: 00000010
@@ -6445,7 +6445,7 @@ ShowText((2011)"And then, as if I am watching her in slow motion she raises her 
 HandleInput(); // 0x8280: 00000010
 LoadSecondEffect(0x39, 0x2, 0x1); // 0x8284: 0000306e
 PlaySecondSoundFx(0xf); // 0x828e: 00001073
-ShowText((2012)"¥"Cybil, it's me. It's Harry!¥" The bullet grazes my shoulder, and with a discordant metallic sound it hits one of the wooden horses. ...She is coming towards me."); // 0x8294: 0000100c
+ShowText((2012)"¥"Cybil, it's me. It's Harry!¥" The bullet grazes my shoulder, and with a discordant metallic sound it hits one of the wooden horses... She is coming towards me."); // 0x8294: 0000100c
 HandleInput(); // 0x829a: 00000010
 CleanScreen(); // 0x829e: 00000064
 LoadBackground(0xaf); // 0x82a2: 00001069
@@ -6453,7 +6453,7 @@ LoadEffect(0x0, 0x0, 0x1); // 0x82a8: 0000306d
 OP_0x65(); // 0x82b2: 00000065
 ShowText((2013)"Her eyes no longer appear to be human. The eerie red color of her eyes does not make it look like her life-force has been drained, but instead, it makes it appear as if she has been possessed by some evil being."); // 0x82b6: 0000100c
 HandleInput(); // 0x82bc: 00000010
-ShowText((2014)"I was too late, I think. Her heart had been devoured by someone, no by Alessa. What is there is no longer Cybil. Just an alter-ego of Alessa that is using Cybil's body..."); // 0x82c0: 0000100c
+ShowText((2014)"I was too late, I think. Her heart had been devoured by someone, no, by Alessa. What is there is no longer Cybil. Just an alter-ego of Alessa that is using Cybil's body..."); // 0x82c0: 0000100c
 HandleInput(); // 0x82c6: 00000010
 Jump(L_0x82d0); // 0x82ca: 00001001
 L_0x82d0:
@@ -6486,7 +6486,7 @@ LoadBackground(0xa3); // 0x835e: 00001069
 OP_0x65(); // 0x8364: 00000065
 ShowText((2019)"Cybil has become just an object. I rush over to Cybil and look at her. She is on her back with her eyes wide open. I sink to the ground. Tears distort my vision."); // 0x8368: 0000100c
 HandleInput(); // 0x836e: 00000010
-ShowText((2020)"¥"Cybil...why... did this happen...¥" At the moment I am about to touch Cybil her back suddenly rises and begins squirming."); // 0x8372: 0000100c
+ShowText((2020)"¥"Cybil... Why... did this happen...?¥" At the moment I am about to touch Cybil her back suddenly rises and begins squirming."); // 0x8372: 0000100c
 HandleInput(); // 0x8378: 00000010
 ShowText((2021)"A nasty liquid-like monster bursts out of Cybil's lifeless back. It crawls on the floor, and begins to move at a speed not unthinkable for its shape."); // 0x837c: 0000100c
 HandleInput(); // 0x8382: 00000010
@@ -6511,7 +6511,7 @@ HandleInput(); // 0x83dc: 00000010
 PlaySecondSoundFx(0x2d); // 0x83e0: 00001073
 ShowText((2027)"And then she brings her arm down and my entire body is blown backwards. My body tumbles across the ground like a rag for about 30 meters, and then finally comes to a rest."); // 0x83e6: 0000100c
 HandleInput(); // 0x83ec: 00000010
-ShowText((2028)"¥"Damn!¥" Such incredible power. A servant of god, a demon's power. A normal person like me has no chance against her. Power is gushing out of her body, and it emits a pale light. I cannot even approach her."); // 0x83f0: 0000100c
+ShowText((2028)"¥"Damn!¥" Such incredible power. A servant of God, a demon's power. A normal person like me has no chance against her. Power is gushing out of her body, and it emits a pale light. I cannot even approach her."); // 0x83f0: 0000100c
 HandleInput(); // 0x83f6: 00000010
 LoadSecondEffect(0x2a, 0x1, 0x1); // 0x83fa: 0000306e
 OP_0x2c(0x3, 0x1); // 0x8404: 0000202c
@@ -6530,12 +6530,12 @@ ShowText((2031)"Just as I was just before, Alessa was blown backwards by that po
 HandleInput(); // 0x8454: 00000010
 ShowText((2032)"¥"Where's Cheryl? Give me back my daughter.¥" I was on the verge of passing out, and I thought of Cheryl. All I can do is calmly look at the unbelievable sight before me as it unfolds before my eyes."); // 0x8458: 0000100c
 HandleInput(); // 0x845e: 00000010
-ShowText((2033)"What just happened? Is Cheryl ok? However, she does not answer me. Instead, a hoarse voice passes into my thoughts, and it is accompanied by the sound of footsteps."); // 0x8462: 0000100c
+ShowText((2033)"What just happened? Is Cheryl okay? However, she does not answer me. Instead, a hoarse voice passes into my thoughts, and it is accompanied by the sound of footsteps."); // 0x8462: 0000100c
 HandleInput(); // 0x8468: 00000010
 OP_0x2c(0x2, 0x1); // 0x846c: 0000202c
 PlayMusic(0x67); // 0x8474: 0000106c
 LoadSecondEffect(0x2b, 0x2, 0x2); // 0x847a: 0000306e
-ShowText((2034)"¥"We meet at last, Alessa.¥" ¥"......!¥" ¥"Dahli. Gillespie......¥""); // 0x8484: 0000100c
+ShowText((2034)"¥"We meet at last, Alessa.¥" ¥"...!¥" ¥"Dahlia Gillespie...¥""); // 0x8484: 0000100c
 HandleInput(); // 0x848a: 00000010
 ShowText((2035)"Unable to move from my prone position I thought about who's voice that was. And then using all my strength I stand. After confirming that it was Dahlia in front of me I spoke in a voice that was nearly a yell."); // 0x848e: 0000100c
 HandleInput(); // 0x8494: 00000010
@@ -6543,7 +6543,7 @@ ShowText((2036)"¥"Where's Cheryl? Where is she?¥""); // 0x8498: 0000100c
 HandleInput(); // 0x849e: 00000010
 ShowText((2037)"Dahlia does not hear me yelling. She does not look back, and looks at Alessa with a creepy smile."); // 0x84a2: 0000100c
 HandleInput(); // 0x84a8: 00000010
-ShowText((2038)"¥"Alessa. This is the end of your little game.¥" ¥"Mama...¥" Mother...? I am confused. ¥"Huh? Could she be...?¥""); // 0x84ac: 0000100c
+ShowText((2038)"¥"Alessa. This is the end of your little game.¥" ¥"Mama...¥" 'Mama'...? I am confused. ¥"Huh? Could she be...?¥""); // 0x84ac: 0000100c
 HandleInput(); // 0x84b2: 00000010
 ShowText((2039)"¥"You've been a ghastly little pest, haven't you? Alessa? I was careless. Thinking you couldn't escape from our spell."); // 0x84b6: 0000100c
 HandleInput(); // 0x84bc: 00000010
@@ -6571,7 +6571,7 @@ LoadBackground(0xc8); // 0x8524: 00001069
 OP_0x65(); // 0x852a: 00000065
 ShowText((2119)"Dahlia and Alessa. It is definitely those two."); // 0x852e: 0000100c
 HandleInput(); // 0x8534: 00000010
-ShowText((2120)"¥"I was shocked to realize the talisman of Metraton was being used. In spite of the lost soul returning at last. Just a little longer and all would have been for naught."); // 0x8538: 0000100c
+ShowText((2120)"¥"I was shocked to realize the talisman of Metatron was being used. In spite of the lost soul returning at last. Just a little longer and all would have been for naught."); // 0x8538: 0000100c
 HandleInput(); // 0x853e: 00000010
 ShowText((2121)"It's all because of that man. We must be thankful to him. Even though Alessa has been stopped, his little girl has to go. What a pity...¥""); // 0x8542: 0000100c
 HandleInput(); // 0x8548: 00000010
@@ -6581,7 +6581,7 @@ ShowText((2123)"¥"Stop this! Dahlia!¥" Dahlia shows no compunction or surprise
 HandleInput(); // 0x855c: 00000010
 ShowText((2124)"¥"Well, well, well. To think you'd make it this far.¥" ¥"Where's Cheryl!? What have you done to her!?¥""); // 0x8560: 0000100c
 HandleInput(); // 0x8566: 00000010
-ShowText((2125)"¥"What are you talking about? You've seen her many times? Restored to her former self.¥" ¥"I'm in no mood for jokes.¥" I didn't understand what she was saying."); // 0x856a: 0000100c
+ShowText((2125)"¥"What are you talking about? You've seen her many times. Restored to her former self.¥" ¥"I'm in no mood for jokes.¥" I didn't understand what she was saying."); // 0x856a: 0000100c
 HandleInput(); // 0x8570: 00000010
 ShowText((2126)"¥"Don't you see? She's right there.¥" Right there? Only Alessa, draped in her blue clothing, is where Dahlia is pointing."); // 0x8574: 0000100c
 HandleInput(); // 0x857a: 00000010
@@ -6649,7 +6649,7 @@ LoadEffect(0x0, 0x0, 0x1); // 0x86ba: 0000306d
 OP_0x65(); // 0x86c4: 00000065
 ShowText((2142)"It has large wings and a head like a bull, and with its green muscles swelling it rose up and out of its mother's body, Alessa. And then it let out an earthshakingly brutal evil cry, and looked down at us."); // 0x86c8: 0000100c
 HandleInput(); // 0x86ce: 00000010
-ShowText((2143)"¥"Huh? What the!?¥" I yell out, not addressing anyone in particular. ¥"What on earth? That's not supposed to...¥" Kaufmann just stands there in utter amazement, as the events unfold unlike how he had expected."); // 0x86d2: 0000100c
+ShowText((2143)"¥"Huh? What the!?¥" I yell out, not addressing anyone in particular. ¥"What on Earth? That's not supposed to...¥" Kaufmann just stands there in utter amazement, as the events unfold unlike how he had expected."); // 0x86d2: 0000100c
 HandleInput(); // 0x86d8: 00000010
 ShowText((2144)"¥"It's awakening! It's awake! Now no one can interfere!¥" Dahlia, in a fit of insanity, had a feeling that could not be described as pleasant or angry."); // 0x86dc: 0000100c
 HandleInput(); // 0x86e2: 00000010
@@ -6662,14 +6662,14 @@ LoadSecondEffect(0x5c, 0x1, 0x1); // 0x86fe: 0000306e
 ShowText((2146)"I edge up to Alessa, the mother's body that has been cast off. And there I see Cheryl, about to fade away as always."); // 0x8708: 0000100c
 HandleInput(); // 0x870e: 00000010
 LoadSecondEffect(0x5d, 0x1, 0x1); // 0x8712: 0000306e
-ShowText((2147)"¥"Thank you Daddy. Goodbye¥" I am certain that is what she said to me. ¥"Cheryl? Can't be? You can't leave like this...¥""); // 0x871c: 0000100c
+ShowText((2147)"¥"Thank you Daddy. Goodbye.¥" I am certain that is what she said to me. ¥"Cheryl? Can't be? You can't leave like this...¥""); // 0x871c: 0000100c
 HandleInput(); // 0x8722: 00000010
 LoadSecondEffect(0x5d, 0x2, 0x1); // 0x8726: 0000306e
 ShowText((2148)"Cheryl is already beginning to run away from me."); // 0x8730: 0000100c
 HandleInput(); // 0x8736: 00000010
 ShowText((2149)"¥"This can't be happening? Cheryl! Cheryl!?¥" I yell out. The figure of my daughter, who I have been searching for, gradually dissolves into the darkness just like the figure I saw when I first arrived in Silent Hill."); // 0x873a: 0000100c
 HandleInput(); // 0x8740: 00000010
-ShowText((2150)"¥"Cheryl!! Wait......¥""); // 0x8744: 0000100c
+ShowText((2150)"¥"Cheryl!! Wait...¥""); // 0x8744: 0000100c
 HandleInput(); // 0x874a: 00000010
 CleanScreen(); // 0x874e: 00000064
 LoadBackground(0x0); // 0x8752: 00001069
@@ -6681,7 +6681,7 @@ ShowText((9998)""); // 0x8772: 0000100c
 LoadSecondEffect(0x2d, 0x2, 0x2); // 0x8778: 0000306e
 WaitTime(0x64); // 0x8782: 0000101f
 LoadSecondEffect(0x0, 0x0, 0x2); // 0x8788: 0000306e
-ShowText((2151)"Then electricity overflowed from the entire body of the creature that was born from Alessa. It divided into several lighting bolts, which struck above my head."); // 0x8792: 0000100c
+ShowText((2151)"Then electricity overflowed from the entire body of the creature that was born from Alessa. It divided into several lightning bolts, which struck above my head."); // 0x8792: 0000100c
 HandleInput(); // 0x8798: 00000010
 ShowText((2152)"I run about trying to escape. However, that band of electricity follows me, and constantly appears in front of me."); // 0x879c: 0000100c
 HandleInput(); // 0x87a2: 00000010
@@ -6694,7 +6694,7 @@ ShowText((9998)""); // 0x87c0: 0000100c
 LoadSecondEffect(0x2d, 0x2, 0x2); // 0x87c6: 0000306e
 WaitTime(0x64); // 0x87d0: 0000101f
 LoadSecondEffect(0x0, 0x0, 0x2); // 0x87d6: 0000306e
-ShowText((2155)"I ready my weapon. During the short time between the lighting strikes I fire many bullets into the creature's body."); // 0x87e0: 0000100c
+ShowText((2155)"I ready my weapon. During the short time between the lightning strikes I fire many bullets into the creature's body."); // 0x87e0: 0000100c
 HandleInput(); // 0x87e6: 00000010
 PlaySecondSoundFx(0xf); // 0x87ea: 00001073
 LoadSecondEffect(0xf, 0x1, 0x2); // 0x87f0: 0000306e
@@ -6770,15 +6770,15 @@ OP_0x65(); // 0x897c: 00000065
 PlayMusic(0x6e); // 0x8980: 0000106c
 LoadSecondEffect(0xc, 0x1, 0x1); // 0x8986: 0000306e
 CleanTextRecord(); // 0x8990: 00000025
-ShowText((2501)"Lisa What happened? Where's Alessa, and Dahlia?"); // 0x8994: 0000100c
+ShowText((2501)"¥"Lisa? What happened? Where's Alessa and Dahlia?¥""); // 0x8994: 0000100c
 HandleInput(); // 0x899a: 00000010
-ShowText((2502)"Harry... Since before... I went to check out the basement like you said..."); // 0x899e: 0000100c
+ShowText((2502)"¥"Harry... Since before... I went to check out the basement like you said...¥""); // 0x899e: 0000100c
 HandleInput(); // 0x89a4: 00000010
-ShowText((2503)"Lisa?"); // 0x89a8: 0000100c
+ShowText((2503)"¥"Lisa?¥""); // 0x89a8: 0000100c
 HandleInput(); // 0x89ae: 00000010
-ShowText((2504)"I was on the verge of passing out, but now I am slowly getting more and more wide awake."); // 0x89b2: 0000100c
+ShowText((2504)"¥"I was on the verge of passing out, but now I am slowly getting more and more wide awake.¥""); // 0x89b2: 0000100c
 HandleInput(); // 0x89b8: 00000010
-ShowText((2505)"¥"Lisa...you went to check out the basement?¥" ¥"Yes...even though I was told never to go there... It was on my mind...¥""); // 0x89bc: 0000100c
+ShowText((2505)"¥"Lisa... You went to check out the basement?¥" ¥"Yes... even though I was told never to go there... It was on my mind...¥""); // 0x89bc: 0000100c
 HandleInput(); // 0x89c2: 00000010
 Jump(L_0x89cc); // 0x89c6: 00001001
 L_0x89cc:
@@ -6819,12 +6819,12 @@ ShowText((2510)"But when I learned that this hospital had a basement by strange 
 HandleInput(); // 0x8a8e: 00000010
 ShowText((2511)"But then he changed. It wasn't just the way he treated me, but he was also irritated with everyone else, and no one wanted to go near him. That was around last summer.¥""); // 0x8a92: 0000100c
 HandleInput(); // 0x8a98: 00000010
-ShowText((2512)"I quietly listen to Lisa's story. ¥"After that he began saying things that did not make a lot of sense. Things like ¥"This is the end of this world¥" and ¥"Descent¥" and so on... Stuff that sounded like weird religious terms..."); // 0x8a9c: 0000100c
+ShowText((2512)"I quietly listen to Lisa's story. ¥"After that he began saying things that did not make a lot of sense. Things like 'This is the end of this world', and 'Descent', and so on... Stuff that sounded like weird religious terms..."); // 0x8a9c: 0000100c
 HandleInput(); // 0x8aa2: 00000010
-ShowText((2513)"¥"That all humans would disappear from the world and only he would survive...¥" ¥"That the landscapes seen by our eyes were all false,¥" he said nothing but things like that..."); // 0x8aa6: 0000100c
+ShowText((2513)"That 'all humans would disappear from the world and only he would survive...' That 'the landscapes seen by our eyes were all false', he said nothing but things like that..."); // 0x8aa6: 0000100c
 HandleInput(); // 0x8aac: 00000010
 OP_0x2c(0x3, 0x1); // 0x8ab0: 0000202c
-ShowText((2514)"And then...he killed himself.¥""); // 0x8ab8: 0000100c
+ShowText((2514)"And then... he killed himself.¥""); // 0x8ab8: 0000100c
 HandleInput(); // 0x8abe: 00000010
 Jump(L_0x8ac8); // 0x8ac2: 00001001
 L_0x8ac8:
@@ -6833,13 +6833,13 @@ Area(0xef); // 0x8ad0: 00001026
 CleanScreen(); // 0x8ad6: 00000064
 LoadBackground(0xa6); // 0x8ada: 00001069
 OP_0x65(); // 0x8ae0: 00000065
-ShowText((2515)"I was stunned. ¥"...Suicide?¥" ¥"Yes...he set himself on fire... The body was unidentifiable.¥" I pressed my hands down on my trembling legs."); // 0x8ae4: 0000100c
+ShowText((2515)"I was stunned. ¥"...Suicide?¥" ¥"Yes... He set himself on fire... The body was unidentifiable.¥" I pressed my hands down on my trembling legs."); // 0x8ae4: 0000100c
 HandleInput(); // 0x8aea: 00000010
 CleanScreen(); // 0x8aee: 00000064
 LoadBackground(0xa6); // 0x8af2: 00001069
 OP_0x65(); // 0x8af8: 00000065
 PlayMusic(0x6f); // 0x8afc: 0000106c
-ShowText((2516)"¥"That...that's impossible! I just met Kaufmann and spoke with him not long ago. Just who was that man?¥" Lisa looks amazed and smiles wryly while shaking her head from side to side."); // 0x8b02: 0000100c
+ShowText((2516)"¥"That... That's impossible! I just met Kaufmann and spoke with him not long ago. Just who was that man?¥" Lisa looks amazed and smiles wryly while shaking her head from side to side."); // 0x8b02: 0000100c
 HandleInput(); // 0x8b08: 00000010
 ShowText((2517)"¥"It was Kaufmann. Doctor Michael Kaufmann... I guess he didn't die after all. There were too many mysteries surrounding his death, and even the police were troubled by it. With no real proof they concluded that it was suicide.¥""); // 0x8b0c: 0000100c
 HandleInput(); // 0x8b12: 00000010
@@ -6871,15 +6871,15 @@ ShowText((2518)"¥"Maybe he switched the bodies?¥" ¥"I don't know... But peopl
 HandleInput(); // 0x8b94: 00000010
 ShowText((2519)"I was at a loss for words."); // 0x8b98: 0000100c
 HandleInput(); // 0x8b9e: 00000010
-ShowText((2520)"¥"Don't tell me... that even you have had contact with him...¥" I recall my conversation with him. A dream? No, I don't think that was a dream. ¥"So...he is in the basement?¥""); // 0x8ba2: 0000100c
+ShowText((2520)"¥"Don't tell me... that even you have had contact with him...¥" I recall my conversation with him. A dream? No, I don't think that was a dream. ¥"So... He is in the basement?¥""); // 0x8ba2: 0000100c
 HandleInput(); // 0x8ba8: 00000010
-ShowText((2521)"¥"I thought that as well. So I fearfully when down to the basement. But after moving just a bit forward I turned back. Just thinking about him being alive in that darkness was too dreadful...¥" As Lisa said this a tear rolled down her cheek."); // 0x8bac: 0000100c
+ShowText((2521)"¥"I thought that as well. So I fearfully when down to the basement. But after moving just a bit forward I turned back. Just thinking about him being alive in that darkness was too dreadful...¥" As Lisa said this, a tear rolled down her cheek."); // 0x8bac: 0000100c
 HandleInput(); // 0x8bb2: 00000010
-ShowText((2522)"I placed my hands on Lisa's shoulders, and made up my mind. ¥"Like I have told you before...I am looking for my daughter, Cheryl. I don't know who this Kaufmann guy really is, but does he know something about the change in this town?¥""); // 0x8bb6: 0000100c
+ShowText((2522)"I placed my hands on Lisa's shoulders, and made up my mind. ¥"Like I have told you before... I am looking for my daughter, Cheryl. I don't know who this Kaufmann guy really is, but does he know something about the change in this town?¥""); // 0x8bb6: 0000100c
 HandleInput(); // 0x8bbc: 00000010
-ShowText((2523)"Lisa doesn't answer. ¥"Lisa, come with me to the basement. That might be where Cheryl is being held. Even if Cheryl is not there if we find Kaufmann then we might be able to talk to him.¥""); // 0x8bc0: 0000100c
+ShowText((2523)"Lisa doesn't answer. ¥"Lisa, come with me to the basement. That might be where Cheryl is being held. Even if Cheryl is not there, if we find Kaufmann then we might be able to talk to him.¥""); // 0x8bc0: 0000100c
 HandleInput(); // 0x8bc6: 00000010
-ShowText((2524)"Lisa thought for a bit and slightly nodded. ¥"...Ok, let's go then.¥""); // 0x8bca: 0000100c
+ShowText((2524)"Lisa thought for a bit and slightly nodded. ¥"...Okay, let's go then.¥""); // 0x8bca: 0000100c
 HandleInput(); // 0x8bd0: 00000010
 Jump(L_0x8bda); // 0x8bd4: 00001001
 L_0x8bda:
@@ -6889,11 +6889,11 @@ OP_0x2c(0x3, 0x1); // 0x8be8: 0000202c
 CleanScreen(); // 0x8bf0: 00000064
 LoadBackground(0xa8); // 0x8bf4: 00001069
 OP_0x65(); // 0x8bfa: 00000065
-ShowText((2525)"Using the flashlight to light our way Lisa and I walked downstairs and headed to the storehouse in the basement. We entered the hidden room in the back of the storehouse and opened the heavy iron grate in the center. Lisa headed in first and I followed behind her."); // 0x8bfe: 0000100c
+ShowText((2525)"Using the flashlight to light our way, Lisa and I walked downstairs and headed to the storehouse in the basement. We entered the hidden room in the back of the storehouse and opened the heavy iron grate in the center. Lisa headed in first and I followed behind her."); // 0x8bfe: 0000100c
 HandleInput(); // 0x8c04: 00000010
 ShowText((2526)"¥"It's cold...¥" Lisa mumbles to herself. It seemed as if we had ended up lost in a giant refrigerator. I couldn't imagine that a person could live down here. I thought about that again."); // 0x8c08: 0000100c
 HandleInput(); // 0x8c0e: 00000010
-ShowText((2527)"If Cheryl is being held down here... My body trembled. Metal Door"); // 0x8c12: 0000100c
+ShowText((2527)"If Cheryl is being held down here... My body trembled."); // 0x8c12: 0000100c
 HandleInput(); // 0x8c18: 00000010
 Jump(L_0x8c22); // 0x8c1c: 00001001
 L_0x8c22:
@@ -6911,7 +6911,7 @@ CleanScreen(); // 0x8c58: 00000064
 LoadBackground(0x0); // 0x8c5c: 00001069
 OP_0x65(); // 0x8c62: 00000065
 PlaySecondSoundFx(0x14); // 0x8c66: 00001073
-ShowText((2530)"The door opened with a 'thunk'. Beyond it a passage no different than the one we had just followed extended. Complete darkness"); // 0x8c6c: 0000100c
+ShowText((2530)"The door opened with a 'thunk'. Beyond it a passage no different than the one we had just followed extended."); // 0x8c6c: 0000100c
 HandleInput(); // 0x8c72: 00000010
 Jump(L_0x8c7c); // 0x8c76: 00001001
 L_0x8c7c:
@@ -6926,19 +6926,19 @@ HandleInput(); // 0x8ca6: 00000010
 OP_0x29(); // 0x8caa: 00000029
 ShowText((2532)"¥"Look!¥" Lisa said."); // 0x8cae: 0000100c
 HandleInput(); // 0x8cb4: 00000010
-ShowText((2533)"¥"Lisa...? What's wrong?¥" ¥"Wait a minute Harry... There is something drawn on the wall.¥""); // 0x8cb8: 0000100c
+ShowText((2533)"¥"Lisa...? What's wrong?¥" ¥"Wait a minute, Harry... There is something drawn on the wall.¥""); // 0x8cb8: 0000100c
 HandleInput(); // 0x8cbe: 00000010
 CleanScreen(); // 0x8cc2: 00000064
 LoadBackground(0xa9); // 0x8cc6: 00001069
 OP_0x65(); // 0x8ccc: 00000065
 PlayMusic(0x67); // 0x8cd0: 0000106c
-ShowText((2534)"I stopped and shined the flashlight on the wall that Lisa was pointing at. ¥"Th...this is...¥" A familiar crest was drawn there. ¥"Does...this mean something?¥""); // 0x8cd6: 0000100c
+ShowText((2534)"I stopped and shined the flashlight on the wall that Lisa was pointing at. ¥"Th...this is...¥" A familiar crest was drawn there. ¥"Does... this mean something?¥""); // 0x8cd6: 0000100c
 HandleInput(); // 0x8cdc: 00000010
-ShowText((2535)"¥"Lisa...since you have not left the hospital you wouldn't know, but this crest has been drawn all throughout this town... Have you not seen it before?¥""); // 0x8ce0: 0000100c
+ShowText((2535)"¥"Lisa... Since you have not left the hospital you wouldn't know, but this crest has been drawn all throughout this town... Have you not seen it before?¥""); // 0x8ce0: 0000100c
 HandleInput(); // 0x8ce6: 00000010
-ShowText((2536)"Lisa looked surprised and muttered. ¥"...Nope...¥" That crest was also drawn on the floor. Upon closer inspection I found that the mark had been inscribed in places all throughout this passage."); // 0x8cea: 0000100c
+ShowText((2536)"Lisa looked surprised and muttered. ¥"...Nope...¥" That crest was also drawn on the floor. Upon closer inspection, I found that the mark had been inscribed in places all throughout this passage."); // 0x8cea: 0000100c
 HandleInput(); // 0x8cf0: 00000010
-ShowText((2537)"The mark of Samael... I recall that that is what Dahlia called it. And then my body trembled... ¥"Alessa... Is Alessa here? In this area...¥" What did you just say..."); // 0x8cf4: 0000100c
+ShowText((2537)"The mark of Samael... I recall that that is what Dahlia called it. And then my body trembled... ¥"Alessa... Is Alessa here? In this area...¥""); // 0x8cf4: 0000100c
 HandleInput(); // 0x8cfa: 00000010
 Jump(L_0x8d04); // 0x8cfe: 00001001
 L_0x8d04:
@@ -6948,22 +6948,22 @@ OP_0x29(); // 0x8d12: 00000029
 CleanScreen(); // 0x8d16: 00000064
 LoadBackground(0xa9); // 0x8d1a: 00001069
 OP_0x65(); // 0x8d20: 00000065
-ShowText((2538)"¥"Eh¥" For an instant we looked each other in the faint light that was lighting the darkness. ¥"What...what did you just say?¥" ¥"I said, Is Alessa here?¥" Lisa's face suddenly twisted in anger."); // 0x8d24: 0000100c
+ShowText((2538)"¥"Huh?¥" For an instant, we looked each other in the faint light that was lighting the darkness. ¥"What... What did you just say?¥" ¥"I said, Is Alessa here?¥" Lisa's face suddenly twisted in anger."); // 0x8d24: 0000100c
 HandleInput(); // 0x8d2a: 00000010
 CleanScreen(); // 0x8d2e: 00000064
 LoadBackground(0xa9); // 0x8d32: 00001069
 OP_0x65(); // 0x8d38: 00000065
 PlayMusic(0x6f); // 0x8d3c: 0000106c
-ShowText((2539)"¥"Why do you know about her? No one should have told you!¥" I was thrown off balance by Lisa's sudden rage. ¥"I saw her several times before I met you. She called Dahlia ¥"Mama¥"... Are those two mother and daughter?¥""); // 0x8d42: 0000100c
+ShowText((2539)"¥"Why do you know about her? No one should have told you!¥" I was thrown off balance by Lisa's sudden rage. ¥"I saw her several times before I met you. She called Dahlia 'Mama'... Are those two mother and daughter?¥""); // 0x8d42: 0000100c
 HandleInput(); // 0x8d48: 00000010
-ShowText((2540)"Lisa looked down and her shoulders shook with anger. I had no idea why. ¥"...What in the world Just what is wrong with you?¥" ¥"I... can no longer trust anyone...¥""); // 0x8d4c: 0000100c
+ShowText((2540)"Lisa looked down and her shoulders shook with anger. I had no idea why. ¥"...What in the world? Just what is wrong with you?¥" ¥"I... can no longer trust anyone...¥""); // 0x8d4c: 0000100c
 HandleInput(); // 0x8d52: 00000010
 ShowText((2541)"¥"Lisa...?¥" ¥"I only did as I was told. Like a true believer obedient to the scripture, I continued even though I lost everything.¥""); // 0x8d56: 0000100c
 HandleInput(); // 0x8d5c: 00000010
-ShowText((2542)"¥"What are you talking about?¥" ¥"However, after all this... There is no such thing as god. There are only ugly humans, ruled by desire!¥" Lisa said that and then forcefully pounded on the wall."); // 0x8d60: 0000100c
+ShowText((2542)"¥"What are you talking about?¥" ¥"However, after all this... There is no such thing as God. There are only ugly humans, ruled by desire!¥" Lisa said that and then forcefully pounded on the wall."); // 0x8d60: 0000100c
 HandleInput(); // 0x8d66: 00000010
 PlaySecondSoundFx(0x28); // 0x8d6a: 00001073
-ShowText((2543)"¥"So you know something. Won't you tell me please, Lisa?¥" Lisa smiles a bit, and then a creepy expression appears on her face. ¥"You too... You are the same as them aren't you? Thinking that you know everything... Even now...¥""); // 0x8d70: 0000100c
+ShowText((2543)"¥"So you know something. Won't you tell me please, Lisa?¥" Lisa smiles a bit, and then a creepy expression appears on her face. ¥"You too... You are the same as them, aren't you? Thinking that you know everything... Even now...¥""); // 0x8d70: 0000100c
 HandleInput(); // 0x8d76: 00000010
 Jump(L_0x8d80); // 0x8d7a: 00001001
 L_0x8d80:
@@ -6973,7 +6973,7 @@ CleanScreen(); // 0x8d8e: 00000064
 LoadBackground(0xa9); // 0x8d92: 00001069
 OP_0x65(); // 0x8d98: 00000065
 PlayMusic(0x6f, 0x1); // 0x8d9c: 0000206c
-Choice((390)"¥".........¥"", (391)"A ) ¥"Who are ¥"they¥"!?¥"", (392)"B ) Show her Alessa's diary."); // 0x8da4: 00003011
+Choice((390)"¥".........¥"", (391)"A ) ¥"Who are 'they'!?¥"", (392)"B ) Show her Alessa's diary."); // 0x8da4: 00003011
 Branch4(0x79e, L_0x8dba); // 0x8dae: 00001004
 Jump(L_0x8dce); // 0x8db4: 00001001
 L_0x8dba:
@@ -6989,9 +6989,9 @@ CleanScreen(); // 0x8ddc: 00000064
 LoadBackground(0xa9); // 0x8de0: 00001069
 OP_0x65(); // 0x8de6: 00000065
 PlayMusic(0x6f, 0x1); // 0x8dea: 0000206c
-ShowText((2544)"¥"Lisa?¥" ¥"Heh-heh...I was a fool.¥" ¥"Lisa! What is this all about? I had an accident while I was headed to this town and lost consciousness. When I came to I found that at some point I had arrived in Silent Hill."); // 0x8df2: 0000100c
+ShowText((2544)"¥"Lisa?¥" ¥"Heh-heh... I was a fool.¥" ¥"Lisa! What is this all about? I had an accident while I was headed to this town and lost consciousness. When I came to I found that at some point I had arrived in Silent Hill."); // 0x8df2: 0000100c
 HandleInput(); // 0x8df8: 00000010
-ShowText((2545)"However, my daughter Cheryl was gone. While searching for her I came into to contact with Kaufmann, Dahlia, and then Alessa. I have already told you all of this. I don't know anything beyond that...really.¥""); // 0x8dfc: 0000100c
+ShowText((2545)"However, my daughter Cheryl was gone. While searching for her I came into to contact with Kaufmann, Dahlia, and then Alessa. I have already told you all of this. I don't know anything beyond that... Really.¥""); // 0x8dfc: 0000100c
 HandleInput(); // 0x8e02: 00000010
 Jump(L_0x8e0c); // 0x8e06: 00001001
 L_0x8e0c:
@@ -7003,9 +7003,9 @@ OP_0x65(); // 0x8e24: 00000065
 PlayMusic(0x6f, 0x1); // 0x8e28: 0000206c
 ShowText((2546)"Before I finish talking Lisa shakes her head back and forth. ¥"It's fine. I was used by that man. I know that. Maybe you are in cahoots with him, or maybe you were used as well. I don't care."); // 0x8e30: 0000100c
 HandleInput(); // 0x8e36: 00000010
-ShowText((2547)"Now that I know I will have my revenge. I continued to believe that she was really Alessa... I never thought that even that was a lie.¥""); // 0x8e3a: 0000100c
+ShowText((2547)"Now that I know, I will have my revenge. I continued to believe that she was really Alessa... I never thought that even that was a lie.¥""); // 0x8e3a: 0000100c
 HandleInput(); // 0x8e40: 00000010
-ShowText((2548)"¥"Used or not... I don't know what you're talking about...¥" Lisa shakes in amazement"); // 0x8e44: 0000100c
+ShowText((2548)"¥"Used or not... I don't know what you're talking about...¥""); // 0x8e44: 0000100c
 HandleInput(); // 0x8e4a: 00000010
 Jump(L_0x8e54); // 0x8e4e: 00001001
 L_0x8e54:
@@ -7015,11 +7015,11 @@ CleanScreen(); // 0x8e62: 00000064
 LoadBackground(0xa9); // 0x8e66: 00001069
 OP_0x65(); // 0x8e6c: 00000065
 PlayMusic(0x6f, 0x1); // 0x8e70: 0000206c
-ShowText((2549)"And then Lisa's face twisted in amazement. ¥"No...don't come...! I only did what I was told!¥""); // 0x8e78: 0000100c
+ShowText((2549)"And then Lisa's face twisted in amazement. ¥"No... Don't come...! I only did what I was told!¥""); // 0x8e78: 0000100c
 HandleInput(); // 0x8e7e: 00000010
 ShowText((2550)"Lisa's sight was fixed on someone behind me. ¥"Lisa...?¥" ¥"Why have you come for me? Shouldn't you be going after someone else! You have no reason to have a grudge against me!¥""); // 0x8e82: 0000100c
 HandleInput(); // 0x8e88: 00000010
-ShowText((2551)"I timidly turned around. ...And at that moment..."); // 0x8e8c: 0000100c
+ShowText((2551)"I timidly turned around... And at that moment..."); // 0x8e8c: 0000100c
 HandleInput(); // 0x8e92: 00000010
 LoadSecondEffect(0x3d, 0x1, 0x0); // 0x8e96: 0000306e
 OP_0x29(); // 0x8ea0: 00000029
@@ -7067,7 +7067,7 @@ HandleInput(); // 0x8f6a: 00000010
 ShowText((2556)"I take a few steps back. And then I decide to try getting away. After a few steps I have no idea of which way I came from."); // 0x8f6e: 0000100c
 HandleInput(); // 0x8f74: 00000010
 PlaySecondSoundFx(0x9); // 0x8f78: 00001073
-ShowText((2557)"Even so I continued to run."); // 0x8f7e: 0000100c
+ShowText((2557)"Even so, I continued to run."); // 0x8f7e: 0000100c
 HandleInput(); // 0x8f84: 00000010
 CleanScreen(); // 0x8f88: 00000064
 LoadBackground(0x0); // 0x8f8c: 00001069
@@ -7177,7 +7177,7 @@ OP_0x65(); // 0x91a4: 00000065
 PlayMusic(0x6e, 0x1); // 0x91a8: 0000206c
 ShowText((4160)"I sensed that Lisa seemed to be having a hard time talking about what we were discussing, so I changed the subject."); // 0x91b0: 0000100c
 HandleInput(); // 0x91b6: 00000010
-ShowText((4161)"¥"Oh...yeah, hey, Lisa. I met a man called Kaufmann in this hospital not long ago. He said that he was a doctor in this hospital, but... Do you know him?¥""); // 0x91ba: 0000100c
+ShowText((4161)"¥"Oh... Yeah, hey, Lisa. I met a man called Kaufmann in this hospital not long ago. He said that he was a doctor in this hospital, but... Do you know him?¥""); // 0x91ba: 0000100c
 HandleInput(); // 0x91c0: 00000010
 ShowText((4162)"Lisa raised her head in surprise, and her eyes opened wide. And then she let out a long sigh."); // 0x91c4: 0000100c
 HandleInput(); // 0x91ca: 00000010
@@ -7189,12 +7189,12 @@ ShowText((4165)"But when I learned that this hospital had a basement by strange 
 HandleInput(); // 0x91e8: 00000010
 ShowText((4166)"But then he changed. It wasn't just the way he treated me, but he was also irritated with everyone else, and no one wanted to go near him. That was around last summer.¥""); // 0x91ec: 0000100c
 HandleInput(); // 0x91f2: 00000010
-ShowText((4167)"I quietly listen to Lisa's story. ¥"After that he began saying things that did not make a lot of sense. Things like ¥"This is the end of this world¥" and ¥"Descent¥" and so on... Stuff that sounded like weird religious terms..."); // 0x91f6: 0000100c
+ShowText((4167)"I quietly listen to Lisa's story. ¥"After that he began saying things that did not make a lot of sense. Things like 'This is the end of this world'. and 'Descent', and so on... Stuff that sounded like weird religious terms..."); // 0x91f6: 0000100c
 HandleInput(); // 0x91fc: 00000010
-ShowText((4168)"¥"That all humans would disappear from the world and only he would survive...¥" ¥"That the landscapes seen by our eyes were all false,¥" he said nothing but things like that..."); // 0x9200: 0000100c
+ShowText((4168)"That 'all humans would disappear from the world and only he would survive...' That 'the landscapes seen by our eyes were all false,' he said nothing but things like that..."); // 0x9200: 0000100c
 HandleInput(); // 0x9206: 00000010
 OP_0x2c(0x3, 0x1); // 0x920a: 0000202c
-ShowText((4169)"And then...he killed himself.¥""); // 0x9212: 0000100c
+ShowText((4169)"And then... he killed himself.¥""); // 0x9212: 0000100c
 HandleInput(); // 0x9218: 00000010
 Jump(L_0x8ac8); // 0x921c: 00001001
 L_0x9222:
@@ -7204,17 +7204,17 @@ CleanScreen(); // 0x9230: 00000064
 LoadBackground(0xa6); // 0x9234: 00001069
 OP_0x65(); // 0x923a: 00000065
 PlayMusic(0x6f, 0x1); // 0x923e: 0000206c
-ShowText((4170)"¥"Wait...Lisa, maybe I mistook him for someone else. After all, since I have come to Silent Hill nothing but strange things have occurred."); // 0x9246: 0000100c
+ShowText((4170)"¥"Wait... Lisa, maybe I mistook him for someone else. After all, since I have come to Silent Hill, nothing but strange things have occurred."); // 0x9246: 0000100c
 HandleInput(); // 0x924c: 00000010
 ShowText((4171)"It is as if I am a walking around in a dream world. Even talking to you now, I cannot say for sure that any of this is real.¥""); // 0x9250: 0000100c
 HandleInput(); // 0x9256: 00000010
-ShowText((4172)"Lisa shakes her head from side to side. ¥"No...it was definitely him. He is alive... He switched the bodies and hid himself... Just what was he up to?¥""); // 0x925a: 0000100c
+ShowText((4172)"Lisa shakes her head from side to side. ¥"No... It was definitely him. He is alive... He switched the bodies and hid himself... Just what was he up to?¥""); // 0x925a: 0000100c
 HandleInput(); // 0x9260: 00000010
-ShowText((4173)"I placed my hands on Lisa's shoulders, and made up my mind. ¥"Like I have told you before...I am looking for my daughter, Cheryl. I don't know who this Kaufmann guy really is, but does he know something about the change in this town?¥""); // 0x9264: 0000100c
+ShowText((4173)"I placed my hands on Lisa's shoulders, and made up my mind. ¥"Like I have told you before... I am looking for my daughter, Cheryl. I don't know who this Kaufmann guy really is, but does he know something about the change in this town?¥""); // 0x9264: 0000100c
 HandleInput(); // 0x926a: 00000010
-ShowText((4174)"Lisa doesn't answer. ¥"Lisa, come with me to the basement. That might be where Cheryl is being held. Even if Cheryl is not there if we find Kaufmann then we might be able to talk to him.¥""); // 0x926e: 0000100c
+ShowText((4174)"Lisa doesn't answer. ¥"Lisa, come with me to the basement. That might be where Cheryl is being held. Even if Cheryl is not there, if we find Kaufmann then we might be able to talk to him.¥""); // 0x926e: 0000100c
 HandleInput(); // 0x9274: 00000010
-ShowText((4175)"Lisa thought for a bit and slightly nodded. ¥"...Ok, let's go then.¥""); // 0x9278: 0000100c
+ShowText((4175)"Lisa thought for a bit and slightly nodded. ¥"...Okay, let's go then.¥""); // 0x9278: 0000100c
 HandleInput(); // 0x927e: 00000010
 Jump(L_0x8bda); // 0x9282: 00001001
 L_0x9288:
@@ -7227,7 +7227,7 @@ OP_0x2c(0x3, 0x1); // 0x92a4: 0000202c
 ShowText((4176)"¥"Here, look at this.¥" Lisa suspiciously snatches it."); // 0x92ac: 0000100c
 HandleInput(); // 0x92b2: 00000010
 PlaySecondSoundFx(0x19); // 0x92b6: 00001073
-ShowText((4177)"¥"April 15¥""); // 0x92bc: 0000100c
+ShowText((4177)"¥"April 15"); // 0x92bc: 0000100c
 HandleInput(); // 0x92c2: 00000010
 PlaySecondSoundFx(0x19); // 0x92c6: 00001073
 ShowText((4501)"From today this will be my new diary. Lisa secretly gave this to me as a present. And it means that soon I should be able to take my bandages off."); // 0x92cc: 0000100c
@@ -7242,13 +7242,13 @@ PlaySecondSoundFx(0x19); // 0x92f6: 00001073
 ShowText((4180)"It is now afternoon, and they have come again. I pretended to be asleep, and it looks like they did not notice."); // 0x92fc: 0000100c
 HandleInput(); // 0x9302: 00000010
 PlaySecondSoundFx(0x19); // 0x9306: 00001073
-ShowText((4181)"They talk quietly as not to be heard outside my room. I do not understand the meaning of what they discussed. They never talk in this room, I thought."); // 0x930c: 0000100c
+ShowText((4181)"They talk quietly as not to be heard outside my room. I do not understand the meaning of what they discussed. They never talk in this room, I thought.¥""); // 0x930c: 0000100c
 HandleInput(); // 0x9312: 00000010
-ShowText((4182)"Lisa raises her head in surprise and I ask her a question. ¥"¥"They¥"...do you mean the ones written about in there?¥" ¥"Where on earth did you get this?¥""); // 0x9316: 0000100c
+ShowText((4182)"Lisa raises her head in surprise and I ask her a question. ¥"'They'... Do you mean the ones written about in there?¥" ¥"Where on Earth did you get this?¥""); // 0x9316: 0000100c
 HandleInput(); // 0x931c: 00000010
 ShowText((4183)"¥"In Alessa's room.¥" ¥"So she kept a diary. She even wrote about me...¥" Lisa smiled a bit."); // 0x9320: 0000100c
 HandleInput(); // 0x9326: 00000010
-ShowText((4184)"¥"Anyway... Are ¥"they¥" the people that Alessa wrote about in there? Lisa? Please tell me what you know.¥""); // 0x932a: 0000100c
+ShowText((4184)"¥"Anyway... Are 'they' the people that Alessa wrote about in there? Lisa? Please tell me what you know.¥""); // 0x932a: 0000100c
 HandleInput(); // 0x9330: 00000010
 Jump(L_0x8e0c); // 0x9334: 00001001
 L_0x933a:
@@ -7263,7 +7263,7 @@ HandleInput(); // 0x9364: 00000010
 PlaySecondSoundFx(0x2b); // 0x9368: 00001073
 ShowText((4186)"From behind me another scream echoed, and it seemed to cut through the air. Was Lisa attacked by something? Or was she transformed?"); // 0x936e: 0000100c
 HandleInput(); // 0x9374: 00000010
-ShowText((4187)"At any rate I was unable to help Lisa."); // 0x9378: 0000100c
+ShowText((4187)"At any rate, I was unable to help Lisa."); // 0x9378: 0000100c
 HandleInput(); // 0x937e: 00000010
 ShowText((4188)"I don't know anything anymore. If what Lisa said was true then Kaufmann might be somewhere down here in this basement."); // 0x9382: 0000100c
 HandleInput(); // 0x9388: 00000010
@@ -7284,7 +7284,7 @@ ShowText((4191)"I gave up my resistance and closed my eyes. As I felt that all m
 HandleInput(); // 0x93d4: 00000010
 ShowText((4192)"My five senses are sharp... A noise that I had not heard until now... Light I had not sensed until now... Something is all around me, and seems to be filling me with its incredible power."); // 0x93d8: 0000100c
 HandleInput(); // 0x93de: 00000010
-ShowText((4193)"The now red light passes through my eyelids, no it should be called a powerful, strong wave of red. It envelops me. My body temperature rises."); // 0x93e2: 0000100c
+ShowText((4193)"The now red light passes through my eyelids, no, it should be called a powerful, strong wave of red. It envelops me. My body temperature rises."); // 0x93e2: 0000100c
 HandleInput(); // 0x93e8: 00000010
 ShowText((4194)"It has come... I must recognize the existence of that great power. However, it doesn't mean that I have forgotten Cheryl."); // 0x93ec: 0000100c
 HandleInput(); // 0x93f2: 00000010
@@ -7310,7 +7310,7 @@ OP_0x29(); // 0x9458: 00000029
 CleanScreen(); // 0x945c: 00000064
 LoadBackground(0xab); // 0x9460: 00001069
 OP_0x65(); // 0x9466: 00000065
-ShowText((3001)"¥"All right...¥" That is as far as my memory goes. Any thing beyond that is vague, and to give an account of it I would have to make things up."); // 0x946a: 0000100c
+ShowText((3001)"¥"All right...¥" That is as far as my memory goes. Anything beyond that is vague, and to give an account of it I would have to make things up."); // 0x946a: 0000100c
 HandleInput(); // 0x9470: 00000010
 ShowText((3002)"However, I do not wish to include any fabrications in this story, that is my true intention. In this case truth is stranger than fiction. But if I said that it was the truth then I doubt anyone would believe me."); // 0x9474: 0000100c
 HandleInput(); // 0x947a: 00000010
@@ -7337,7 +7337,7 @@ PlaySecondSoundFx(0x1f); // 0x94dc: 00001073
 CleanScreen(); // 0x94e2: 00000064
 LoadBackground(0xac); // 0x94e6: 00001069
 OP_0x65(); // 0x94ec: 00000065
-ShowText((3009)"¥"Daddy¥" I turn around and Cheryl is standing there pouting. ¥"Ah, sorry. I have just finished. Sorry to have kept you waiting.¥" Cheryl smiled, returned to her room downstairs, and pulled several of her best outfits out of a wardrobe."); // 0x94f0: 0000100c
+ShowText((3009)"¥"Daddy.¥" I turn around and Cheryl is standing there pouting. ¥"Ah, sorry. I have just finished. Sorry to have kept you waiting.¥" Cheryl smiled, returned to her room downstairs, and pulled several of her best outfits out of a wardrobe."); // 0x94f0: 0000100c
 HandleInput(); // 0x94f6: 00000010
 CleanScreen(); // 0x94fa: 00000064
 LoadBackground(0x0); // 0x94fe: 00001069
@@ -7348,7 +7348,7 @@ CleanScreen(); // 0x9512: 00000064
 LoadBackground(0xad); // 0x9516: 00001069
 OP_0x65(); // 0x951c: 00000065
 PlaySoundFx(0x17); // 0x9520: 00001072
-ShowText((3011)"Ziriririri... The phone rings. Who is it?"); // 0x9526: 0000100c
+ShowText((3011)"Riiing... Riiing... The phone rings. Who is it?"); // 0x9526: 0000100c
 HandleInput(); // 0x952c: 00000010
 Jump(L_0x9536); // 0x9530: 00001001
 L_0x9536:
@@ -7384,13 +7384,13 @@ CleanScreen(); // 0x95c6: 00000064
 LoadBackground(0xad); // 0x95ca: 00001069
 OP_0x65(); // 0x95d0: 00000065
 PlaySoundFx(0x17, 0x1); // 0x95d4: 00002072
-ShowText((3013)"¥"Daddy! Are you here?¥" Cheryl called out in a loud voice right after Harry left the house. There is no answer. There is no helping it. With no other choice Cheryl rushed to the phone and picked up the receiver."); // 0x95dc: 0000100c
+ShowText((3013)"¥"Daddy! Are you here?¥" Cheryl called out in a loud voice right after Harry left the house. There is no answer. There is no helping it. With no other choice, Cheryl rushed to the phone and picked up the receiver."); // 0x95dc: 0000100c
 HandleInput(); // 0x95e2: 00000010
 OP_0x29(); // 0x95e6: 00000029
 PlaySecondSoundFx(0x18); // 0x95ea: 00001073
 ShowText((3014)"¥"Hello.¥" ¥"Oh, Cheryl. It's daddy.¥" ¥"Daddy? Where are you now?¥" ¥"I am in front of the mailbox. I am meeting an acquaintance of mine. I will be done soon.¥""); // 0x95f0: 0000100c
 HandleInput(); // 0x95f6: 00000010
-ShowText((3015)"¥"Hurry up and come home. Or else it will get late.¥" ¥"Yeah...sorry. I will hurry home. By the way Cheryl, there is a place I want to stop before we go to the amusement park. Is that ok?¥" ¥"Where?¥""); // 0x95fa: 0000100c
+ShowText((3015)"¥"Hurry up and come home. Or else it will get late.¥" ¥"Yeah... Sorry. I will hurry home. By the way Cheryl, there is a place I want to stop before we go to the amusement park. Is that okay?¥" ¥"Where?¥""); // 0x95fa: 0000100c
 HandleInput(); // 0x9600: 00000010
 ShowText((3016)"¥"Silent Hill.¥""); // 0x9604: 0000100c
 HandleInput(); // 0x960a: 00000010
@@ -7418,7 +7418,7 @@ ShowText((4199)"¥"Hello...¥" ..........................."); // 0x9676: 0000100
 HandleInput(); // 0x967c: 00000010
 ShowText((4200)"The telephone is silent... Perhaps it's a prank call?"); // 0x9680: 0000100c
 HandleInput(); // 0x9686: 00000010
-ShowText((4201)"¥"Hello? If you have nothing to say then I am going to hang up. I have no interest in dealing with a prank call.¥" At the moment I was about to hang up the receiver the unseen caller finally spoke."); // 0x968a: 0000100c
+ShowText((4201)"¥"Hello? If you have nothing to say then I am going to hang up. I have no interest in dealing with a prank call.¥" At the moment I was about to hang up the receiver the unseen caller finally spoke up."); // 0x968a: 0000100c
 HandleInput(); // 0x9690: 00000010
 PlayMusic(0x6e); // 0x9694: 0000106c
 ShowText((4202)"(......Hello......) My hand holding the receiver trembles. That voice is...!"); // 0x969a: 0000100c
@@ -7426,7 +7426,7 @@ HandleInput(); // 0x96a0: 00000010
 PlaySecondSoundFx(0x18); // 0x96a4: 00001073
 WaitTime(0xa0); // 0x96aa: 0000101f
 PlaySoundFx(0x16); // 0x96b0: 00001072
-ShowText((4203)"That voice is...... There is no doubt. The receiver fell to the floor, but I did not notice."); // 0x96b6: 0000100c
+ShowText((4203)"That voice is... There is no doubt. The receiver fell to the floor, but I did not notice."); // 0x96b6: 0000100c
 HandleInput(); // 0x96bc: 00000010
 CleanScreen(); // 0x96c0: 00000064
 LoadBackground(0x0); // 0x96c4: 00001069
@@ -7445,7 +7445,7 @@ OP_0x65(); // 0x970a: 00000065
 PlaySecondSoundFx(0x1f); // 0x970e: 00001073
 ShowText((4206)"I rush up the stairs. ¥"Cheryl...!¥" Cheryl had completed getting ready, and was sitting quietly on a three-legged wooden chair."); // 0x9714: 0000100c
 HandleInput(); // 0x971a: 00000010
-ShowText((4207)"¥"What's wrong? Daddy?¥" ¥"I'm sorry...but something urgent has come up. It doesn't look like we will be able to go to the amusement park. I will have to leave you here alone, but...will you be ok?¥""); // 0x971e: 0000100c
+ShowText((4207)"¥"What's wrong? Daddy?¥" ¥"I'm sorry... but something urgent has come up. It doesn't look like we will be able to go to the amusement park. I will have to leave you here alone, but... will you be okay?¥""); // 0x971e: 0000100c
 HandleInput(); // 0x9724: 00000010
 ShowText((4208)"The expression that I expected appeared on Cheryl's face. ¥"Hey, you promised!¥" ¥"I'm sorry... I have to go right away...¥""); // 0x9728: 0000100c
 HandleInput(); // 0x972e: 00000010
@@ -7501,7 +7501,7 @@ CleanScreen(); // 0x9830: 00000064
 LoadBackground(0x78); // 0x9834: 00001069
 LoadEffect(0xe, 0x1, 0x0); // 0x983a: 0000306d
 OP_0x65(); // 0x9844: 00000065
-ShowText((3506)"Everything has been unreasonable and illogical. My irritation is increasing, and I will end up losing my cool. The antique shop? Yeah...this is it."); // 0x9848: 0000100c
+ShowText((3506)"Everything has been unreasonable and illogical. My irritation is increasing, and I will end up losing my cool. The antique shop? Yeah... This is it."); // 0x9848: 0000100c
 HandleInput(); // 0x984e: 00000010
 ShowText((3507)"For a moment I was taken with the sense that someone was watching me, but without looking back I entered the door as if I was being swallowed by it."); // 0x9852: 0000100c
 HandleInput(); // 0x9858: 00000010
@@ -7527,11 +7527,11 @@ ShowText((3511)"¥"Oh, I'm glad you're OK. I shouldn't have left you. Things are
 HandleInput(); // 0x98ca: 00000010
 ShowText((3512)"¥"I saw you go in here, so I followed you. I couldn't get out. All the roads out of town are blocked. Cars have completely stopped running. The phones and radios are still out, too.¥""); // 0x98ce: 0000100c
 HandleInput(); // 0x98d4: 00000010
-ShowText((3513)"¥"What about my daughter? Did you see her?¥" No, Cybil shook her head back and forth. ¥"Unfortunately...I haven't.¥" I looked down."); // 0x98d8: 0000100c
+ShowText((3513)"¥"What about my daughter? Did you see her?¥" No, Cybil shook her head back and forth. ¥"Unfortunately... I haven't.¥" I looked down."); // 0x98d8: 0000100c
 HandleInput(); // 0x98de: 00000010
-ShowText((3514)"¥"What about you, anything?¥" ¥"Yeah... I met this bizarre woman. Her name's Dahlia Gillespie. Do you know her?¥" ¥"Dahlia Gillespie? I just met her at the church. Something about her...she is quite a creepy person.¥""); // 0x98e2: 0000100c
+ShowText((3514)"¥"What about you, anything?¥" ¥"Yeah... I met this bizarre woman. Her name's Dahlia Gillespie. Do you know her?¥" ¥"Dahlia Gillespie? I just met her at the church. Something about her... she is quite a creepy person.¥""); // 0x98e2: 0000100c
 HandleInput(); // 0x98e8: 00000010
-ShowText((3515)"¥"She said something about the town being devoured by darkness. Gibberish like that. Any idea what it means?¥" ¥"Hmm...I really don't know... As for me, she said ¥"You can no longer make it time¥" and such, things I did not understand the meaning of.¥""); // 0x98ec: 0000100c
+ShowText((3515)"¥"She said something about the town being devoured by darkness. Gibberish like that. Any idea what it means?¥" ¥"Hmm... I really don't know... As for me, she said 'You can no longer make it time' and such, things I did not understand the meaning of.¥""); // 0x98ec: 0000100c
 HandleInput(); // 0x98f2: 00000010
 ShowText((3516)"We then just looked at each other for bit, each of us thinking of something. ¥"How is the gun I gave you?¥" Cybil asked with a bright smile."); // 0x98f6: 0000100c
 HandleInput(); // 0x98fc: 00000010
@@ -7555,7 +7555,7 @@ ShowText((3519)"My body, and the images entering my pupils, it all seems like I 
 HandleInput(); // 0x9968: 00000010
 ShowText((3520)"Cybil's calls brought me back around. ¥"...rry...¥""); // 0x996c: 0000100c
 HandleInput(); // 0x9972: 00000010
-ShowText((3521)"¥"Hey! Harry?¥" ¥"Uh...yeah... What's wrong?¥" Cybil looked slightly irritated and took a long breath. Then she shifted her gaze to the passage behind the shelf."); // 0x9976: 0000100c
+ShowText((3521)"¥"Hey! Harry?¥" ¥"Uh... Yeah... What's wrong?¥" Cybil looked slightly irritated and took a long breath. Then she shifted her gaze to the passage behind the shelf."); // 0x9976: 0000100c
 HandleInput(); // 0x997c: 00000010
 CleanScreen(); // 0x9980: 00000064
 LoadBackground(0x7e); // 0x9984: 00001069
@@ -7563,7 +7563,7 @@ LoadEffect(0x0, 0x0, 0x1); // 0x998a: 0000306d
 OP_0x65(); // 0x9994: 00000065
 ShowText((3522)"¥"What's this?¥" ¥"Just discovered it.¥" ¥"Maybe there's something back there. Let's have a look.¥" ¥"Wait. We don't know what's back there. I'd better check it out first.¥""); // 0x9998: 0000100c
 HandleInput(); // 0x999e: 00000010
-ShowText((3523)"I'm a cop, I should go.¥" ¥"No. I'm going.¥" Cybil placed her hand over my mouth to keep me from speaking. ¥"Even though I look like this I am a police officer. Please leave everything to me. Think of this as my job.¥""); // 0x99a2: 0000100c
+ShowText((3523)"¥"I'm a cop, I should go.¥" ¥"No. I'm going.¥" Cybil placed her hand over my mouth to keep me from speaking. ¥"Even though I look like this I am a police officer. Please leave everything to me. Think of this as my job.¥""); // 0x99a2: 0000100c
 HandleInput(); // 0x99a8: 00000010
 ShowText((3524)"I remained silent for a bit and then gave in to her. ¥"Okay, please be careful.¥""); // 0x99ac: 0000100c
 HandleInput(); // 0x99b2: 00000010
@@ -7589,7 +7589,7 @@ CleanScreen(); // 0x9a14: 00000064
 LoadBackground(0x0); // 0x9a18: 00001069
 LoadEffect(0x0, 0x0, 0x1); // 0x9a1e: 0000306d
 OP_0x65(); // 0x9a28: 00000065
-ShowText((3532)"Leaving me behind Cybil steps into the passage. I can no longer see her from where I am at."); // 0x9a2c: 0000100c
+ShowText((3532)"Leaving me behind, Cybil steps into the passage. I can no longer see her from where I am at."); // 0x9a2c: 0000100c
 HandleInput(); // 0x9a32: 00000010
 Jump(L_0x9a3c); // 0x9a36: 00001001
 L_0x9a3c:
@@ -7631,13 +7631,13 @@ ShowText((3541)".................."); // 0x9b00: 0000100c
 HandleInput(); // 0x9b06: 00000010
 ShowText((3542)"My body is freezing. Where am I...? I cannot focus my eyes."); // 0x9b0a: 0000100c
 HandleInput(); // 0x9b10: 00000010
-ShowText((3543)"That's right...this is the antique shop... I am sitting on the floor with my back against the cold wall. I must have dozed off for a bit. My fingers are as cold as ice and so I cannot move them normally."); // 0x9b14: 0000100c
+ShowText((3543)"That's right... This is the antique shop... I am sitting on the floor with my back against the cold wall. I must have dozed off for a bit. My fingers are as cold as ice and so I cannot move them normally."); // 0x9b14: 0000100c
 HandleInput(); // 0x9b1a: 00000010
 ShowText((3544)"While chasing around after Cheryl fatigue must have been building up without me realizing it. However, this is no time to be sleeping."); // 0x9b1e: 0000100c
 HandleInput(); // 0x9b24: 00000010
 ShowText((3545)"Oh, I wonder how Cybil is doing? I look around the room and see that the eerie passage that was hidden behind the shelf is still open just as it was before."); // 0x9b28: 0000100c
 HandleInput(); // 0x9b2e: 00000010
-ShowText((3546)"Cybil is still in there. When she comes out I will have a word with her... I hope she is ok. It seems like quite a bit of time has passed."); // 0x9b32: 0000100c
+ShowText((3546)"Cybil is still in there. When she comes out I will have a word with her... I hope she is okay. It seems like quite a bit of time has passed."); // 0x9b32: 0000100c
 HandleInput(); // 0x9b38: 00000010
 OP_0x2c(0x3, 0x1); // 0x9b3c: 0000202c
 Jump(L_0x9b4a); // 0x9b44: 00001001
@@ -7677,7 +7677,7 @@ ShowText((3551)"There was a room at the end of the passage. As I enter the room 
 HandleInput(); // 0x9c0a: 00000010
 ShowText((3552)"There is a simple altar on the wall to the right of where I entered the room. A large flame is coming off of a thick candle and green smoke is billowing from it. Everything in the room was shaking in the light from that flame."); // 0x9c0e: 0000100c
 HandleInput(); // 0x9c14: 00000010
-ShowText((3553)"¥"What...is this place...?¥" Once my eyes adjusted to the light my line of sight jumped to an unbelievable sight."); // 0x9c18: 0000100c
+ShowText((3553)"¥"What... is this place...?¥" Once my eyes adjusted to the light my line of sight jumped to an unbelievable sight."); // 0x9c18: 0000100c
 HandleInput(); // 0x9c1e: 00000010
 OP_0x2c(0x2, 0x1); // 0x9c22: 0000202c
 LoadSecondEffect(0x37, 0x0, 0x1); // 0x9c2a: 0000306e
@@ -7686,7 +7686,7 @@ CleanScreen(); // 0x9c3e: 00000064
 LoadBackground(0xa3); // 0x9c42: 00001069
 OP_0x65(); // 0x9c48: 00000065
 OP_0x29(); // 0x9c4c: 00000029
-ShowText((3554)"At first, I thought it was just a well made doll. A mannequin with a red shirt on... It was on its back, lying in a pool of red liquid. But...I soon understood what it was."); // 0x9c50: 0000100c
+ShowText((3554)"At first, I thought it was just a well made doll. A mannequin with a red shirt on... It was on its back, lying in a pool of red liquid. But... I soon understood what it was."); // 0x9c50: 0000100c
 HandleInput(); // 0x9c56: 00000010
 ShowText((3555)"Cybil. I softly call to her. Her light green shirt had been stained crimson by the flow of red liquid from the back of her neck."); // 0x9c5a: 0000100c
 HandleInput(); // 0x9c60: 00000010
@@ -7714,9 +7714,9 @@ LoadBackground(0xa3); // 0x9cc2: 00001069
 OP_0x65(); // 0x9cc8: 00000065
 ShowText((3556)"¥"...Cybil. ...Cybil! Hold on!¥" I shake her shoulders. But she does not respond."); // 0x9ccc: 0000100c
 HandleInput(); // 0x9cd2: 00000010
-ShowText((3557)"¥"Why has this happened...!¥" I cover her dead body. Her cold body."); // 0x9cd6: 0000100c
+ShowText((3557)"¥"Why has this happened...!?¥" I cover her dead body. Her cold body."); // 0x9cd6: 0000100c
 HandleInput(); // 0x9cdc: 00000010
-ShowText((3558)"Lost in hopelessness I lost consciousness again."); // 0x9ce0: 0000100c
+ShowText((3558)"Lost in hopelessness, I lost consciousness again."); // 0x9ce0: 0000100c
 HandleInput(); // 0x9ce6: 00000010
 CleanScreen(); // 0x9cea: 00000064
 LoadBackground(0x0); // 0x9cee: 00001069
@@ -7730,40 +7730,40 @@ CleanScreen(); // 0x9d12: 00000064
 LoadBackground(0x0); // 0x9d16: 00001069
 OP_0x65(); // 0x9d1c: 00000065
 PlaySoundFx(0x39); // 0x9d20: 00001072
-ShowText((3559)"...rry? Are you OK? Harry? Harry? .............................. Where am I? Harry. Lisa... Then I'm in the hospital."); // 0x9d26: 0000100c
+ShowText((3559)"¥"...rry? Are you OK? Harry? Harry?¥" .............................. ¥"Where am I?¥" ¥"Harry.¥" ¥"Lisa... Then I'm in the hospital.¥""); // 0x9d26: 0000100c
 HandleInput(); // 0x9d2c: 00000010
 CleanScreen(); // 0x9d30: 00000064
 LoadBackground(0x69); // 0x9d34: 00001069
 OP_0x65(); // 0x9d3a: 00000065
 LoadSecondEffect(0x33, 0x1, 0x1); // 0x9d3e: 0000306e
-ShowText((3560)"You were having a bad dream. Was I? Hey, you don't look too good. Are you OK? I'm fine. Nothing you need to worry about. Well, if you're sure....."); // 0x9d48: 0000100c
+ShowText((3560)"¥"You were having a bad dream.¥" ¥"Was I? Hey, you don't look too good. Are you OK?¥" ¥"I'm fine. Nothing you need to worry about.¥" ¥"Well, if you're sure..."); // 0x9d48: 0000100c
 HandleInput(); // 0x9d4e: 00000010
-ShowText((3561)"Lisa...... Do you know a woman named Dahlia Gillespie?"); // 0x9d52: 0000100c
+ShowText((3561)"Lisa... Do you know a woman named Dahlia Gillespie?¥""); // 0x9d52: 0000100c
 HandleInput(); // 0x9d58: 00000010
-ShowText((3562)"Oh yeah, that crazy Gillespie lady. She's kind of famous around here. She never sees anybody, so I don't know that much about her."); // 0x9d5c: 0000100c
+ShowText((3562)"¥"Oh yeah, that crazy Gillespie lady. She's kinda' famous around here. She never sees anybody, so I don't know that much about her."); // 0x9d5c: 0000100c
 HandleInput(); // 0x9d62: 00000010
-ShowText((3563)"But I heard her kid died in a fire, and supposedly she's been crazy ever since. Well, she says the town is being devoured by the darkness. Do you have any idea what she's talking about?"); // 0x9d66: 0000100c
+ShowText((3563)"But I heard her kid died in a fire, and supposedly she's been crazy ever since.¥" ¥"Well, she says the town is being devoured by the darkness. Do you have any idea what she's talking about?¥""); // 0x9d66: 0000100c
 HandleInput(); // 0x9d6c: 00000010
-ShowText((3564)"The town...devoured by the darkness. Yes, I think I do. Before this place was turned into a resort, the townspeople here were on the quiet side."); // 0x9d70: 0000100c
+ShowText((3564)"¥"The town... devoured by the darkness. Yes, I think I do. Before this place was turned into a resort, the townspeople here were on the quiet side."); // 0x9d70: 0000100c
 HandleInput(); // 0x9d76: 00000010
 ShowText((3565)"Everybody followed some kind of queer religion... Weird occult stuff... Black magic, that kind of thing."); // 0x9d7a: 0000100c
 HandleInput(); // 0x9d80: 00000010
 ShowText((3566)"As young people moved away, the people figured they'd been summoned by the gods. Evidently, things like that used to happen around here all the time."); // 0x9d84: 0000100c
 HandleInput(); // 0x9d8a: 00000010
-ShowText((3567)"Before the resort, there wasn't really anything else out here. Everyone was so flipped out. Gotta blame it on something. Then a lot of new people came in and everybody clammed up about it."); // 0x9d8e: 0000100c
+ShowText((3567)"Before the resort, there wasn't really anything else out here. Everyone was so flipped out. Gotta blame it on something. Then a lot of new people came in and everybody clammed up about it.¥""); // 0x9d8e: 0000100c
 HandleInput(); // 0x9d94: 00000010
 LoadSecondEffect(0x33, 0x2, 0x1); // 0x9d98: 0000306e
-ShowText((3568)"A cult... Last time I heard anything about it was, gosh, years ago... When several people connected with developing the town died in accidents. People said it was a curse."); // 0x9da2: 0000100c
+ShowText((3568)"¥"A cult...¥" ¥"Last time I heard anything about it was, gosh, years ago... When several people connected with developing the town died in accidents. People said it was a curse."); // 0x9da2: 0000100c
 HandleInput(); // 0x9da8: 00000010
-ShowText((3569)"Oh, I'm sorry. I'm rambling... I'll shut up. ............................... No...it's all right."); // 0x9dac: 0000100c
+ShowText((3569)"Oh, I'm sorry. I'm rambling... I'll shut up.¥" ............................... ¥"No...it's all right.¥""); // 0x9dac: 0000100c
 HandleInput(); // 0x9db2: 00000010
-ShowText((3570)"Hey, Harry. What happened...to your hand...? Oh, this... I just hurt it a little bit."); // 0x9db6: 0000100c
+ShowText((3570)"¥"Hey, Harry. What happened... to your hand...?¥" ¥"Oh, this...? I just hurt it a little bit.¥""); // 0x9db6: 0000100c
 HandleInput(); // 0x9dbc: 00000010
-ShowText((3571)"Is it OK? Yeah...just a scratch... Nothing major... Even if it is just a scratch there is a lot of blood... If we don't look after it soon..."); // 0x9dc0: 0000100c
+ShowText((3571)"¥"Is it OK?¥" ¥"Yeah... just a scratch... Nothing major...¥" ¥"Even if it is just a scratch there is a lot of blood... If we don't look after it soon...¥""); // 0x9dc0: 0000100c
 HandleInput(); // 0x9dc6: 00000010
-ShowText((3572)"It's OK... Please don't touch it. ...Why are you so angry? ...Sorry. ...But this does not concern you. ...I don't want to get you mixed up in this..."); // 0x9dca: 0000100c
+ShowText((3572)"¥"It's OK... Please don't touch it.¥" ¥"...Why are you so angry?¥" ¥"...Sorry... But this does not concern you. ...I don't want to get you mixed up in this..."); // 0x9dca: 0000100c
 HandleInput(); // 0x9dd0: 00000010
-ShowText((3573)"...I'm sorry... Lisa's words"); // 0x9dd4: 0000100c
+ShowText((3573)"...I'm sorry...¥""); // 0x9dd4: 0000100c
 HandleInput(); // 0x9dda: 00000010
 LoadSecondEffect(0x33, 0x0, 0x1); // 0x9dde: 0000306e
 LoadSecondEffect(0x0, 0x0, 0x1); // 0x9de8: 0000306e
@@ -7815,18 +7815,18 @@ HandleInput(); // 0x9ece: 00000010
 LoadSecondEffect(0x33, 0x1, 0x1); // 0x9ed2: 0000306e
 ShowText((3582)"¥"Harry!¥" She changes from looking completely exhausted and rushes over to me in an innocent childlike way."); // 0x9edc: 0000100c
 HandleInput(); // 0x9ee2: 00000010
-ShowText((3583)"¥"Glad you're OK.¥" ¥"Thank god you came back! I was scared to be here all alone!¥" ¥"I'm here now. I was worried, too. I'm real happy to see you.¥""); // 0x9ee6: 0000100c
+ShowText((3583)"¥"Glad you're OK.¥" ¥"Thank God you came back! I was scared to be here all alone!¥" ¥"I'm here now. I was worried, too. I'm real happy to see you.¥""); // 0x9ee6: 0000100c
 HandleInput(); // 0x9eec: 00000010
 ShowText((3584)"I lightly hug Lisa and gently draw away. I then speak while looking into her eyes."); // 0x9ef0: 0000100c
 HandleInput(); // 0x9ef6: 00000010
 ShowText((3585)"¥"Lisa...have you seen a police woman named Cybil?¥" ¥"Cybil...? That is the first time I have heard that name... I have not seen her... Since the town has become like this I have not met any humans other than you.¥""); // 0x9efa: 0000100c
 HandleInput(); // 0x9f00: 00000010
-ShowText((3586)"I was irritated that I didn't understand anything that was going on, so I loudly clicked my tongue. ¥"What's wrong Harry? You don't seem yourself.¥" ¥"Sorry… I just cannot see the truth. Even talking to you now, I wonder if it isn't just a delusion.¥""); // 0x9f04: 0000100c
+ShowText((3586)"I was irritated that I didn't understand anything that was going on, so I loudly clicked my tongue. ¥"What's wrong, Harry? You don't seem yourself.¥" ¥"Sorry... I just cannot see the truth. Even talking to you now, I wonder if it isn't just a delusion.¥""); // 0x9f04: 0000100c
 HandleInput(); // 0x9f0a: 00000010
 LoadSecondEffect(0x33, 0x2, 0x1); // 0x9f0e: 0000306e
 ShowText((3587)"Lisa looks a bit sad. ¥"I am me. Nothing has changed. I have just been waiting for you here all along.¥" Saying nothing, I just looked at Lisa."); // 0x9f18: 0000100c
 HandleInput(); // 0x9f1e: 00000010
-ShowText((3588)"While we were talking I couldn't be sure if that I was currently sitting here or actually speaking. My voice and my existence were beginning to disappear into the dry air in the room..."); // 0x9f22: 0000100c
+ShowText((3588)"While we were talking, I couldn't be sure if that I was currently sitting here or actually speaking. My voice and my existence were beginning to disappear into the dry air in the room..."); // 0x9f22: 0000100c
 HandleInput(); // 0x9f28: 00000010
 Jump(L_0x9f32); // 0x9f2c: 00001001
 L_0x9f32:
@@ -7852,7 +7852,7 @@ ShowText((3593)"¥"It was no good. All the roads are blocked. It is impossible t
 HandleInput(); // 0x9fa8: 00000010
 ShowText((3594)"¥"I grew up in this town. I know this area. As far as I could see all the roads leading out of town have become precipitous cliffs or were blocked with large boulders. We are completely isolated.¥""); // 0x9fac: 0000100c
 HandleInput(); // 0x9fb2: 00000010
-ShowText((3595)"Lisa's smile disappeared. ¥"Well...what are we going to do?¥" (Lisa) ¥"We should start thinking about that. I am going to get some sleep...¥" With that Kaufmann left the room."); // 0x9fb6: 0000100c
+ShowText((3595)"Lisa's smile disappeared. ¥"Well... What are we going to do?¥" ¥"We should start thinking about that. I am going to get some sleep...¥" With that Kaufmann left the room."); // 0x9fb6: 0000100c
 HandleInput(); // 0x9fbc: 00000010
 LoadSecondEffect(0x34, 0x0, 0x1); // 0x9fc0: 0000306e
 LoadSecondEffect(0x0, 0x0, 0x1); // 0x9fca: 0000306e
@@ -7908,7 +7908,7 @@ LoadBackground(0x0); // 0xa0ce: 00001069
 OP_0x65(); // 0xa0d4: 00000065
 PlaySoundFx(0x39, 0x1); // 0xa0d8: 00002072
 PlaySecondSoundFx(0x9); // 0xa0e0: 00001073
-ShowText((3605)"(Click...Click......) (Onomatopoeia for footsteps) Footsteps? I turned back and as I approached the long corridor on the first floor I saw it."); // 0xa0e6: 0000100c
+ShowText((3605)"(Clack, clack...) Footsteps? I turned back and as I approached the long corridor on the first floor I saw it."); // 0xa0e6: 0000100c
 HandleInput(); // 0xa0ec: 00000010
 CleanScreen(); // 0xa0f0: 00000064
 LoadBackground(0x96); // 0xa0f4: 00001069
@@ -7928,7 +7928,7 @@ CleanScreen(); // 0xa140: 00000064
 LoadBackground(0x7f); // 0xa144: 00001069
 OP_0x65(); // 0xa14a: 00000065
 PlayMusic(0x71); // 0xa14e: 0000106c
-ShowText((3609)"I open the door. The faint scent of gun power wafts through the air... And in the middle of the room Lisa lay on her side, dead."); // 0xa154: 0000100c
+ShowText((3609)"I open the door. The faint scent of gunpowder wafts through the air... And in the middle of the room Lisa lay on her side, dead."); // 0xa154: 0000100c
 HandleInput(); // 0xa15a: 00000010
 Jump(L_0xa164); // 0xa15e: 00001001
 L_0xa164:
@@ -7952,7 +7952,7 @@ Area(0x11d); // 0xa1b8: 00001026
 CleanScreen(); // 0xa1be: 00000064
 LoadBackground(0x7f); // 0xa1c2: 00001069
 OP_0x65(); // 0xa1c8: 00000065
-Choice((440)"¥".........¥"", (441)"A ) Pursue the girl I just saw.", (442)"B ) Or maybe the culprit is someone else...yes, and they are still close..."); // 0xa1cc: 00003011
+Choice((440)"¥".........¥"", (441)"A ) Pursue the girl I just saw.", (442)"B ) Or maybe the culprit is someone else... Yes, and they are still close..."); // 0xa1cc: 00003011
 Branch4(0x7e4, L_0xa1e2); // 0xa1d6: 00001004
 Jump(L_0xa1f6); // 0xa1dc: 00001001
 L_0xa1e2:
@@ -7989,7 +7989,7 @@ ShowText((3617)"Upon seeing his injury I sank to the ground. I sat with my legs 
 HandleInput(); // 0xa276: 00000010
 ShowText((3618)"However, that girl is not here now."); // 0xa27a: 0000100c
 HandleInput(); // 0xa280: 00000010
-ShowText((3619)"I bury my face in my hands. I thought, please kill me soon. As each of the people in town are killed... I don't want to be the last one, please...kill me soon."); // 0xa284: 0000100c
+ShowText((3619)"I bury my face in my hands. I thought, please kill me soon. As each of the people in town are killed... I don't want to be the last one, please... Kill me soon."); // 0xa284: 0000100c
 HandleInput(); // 0xa28a: 00000010
 Jump(L_0xa294); // 0xa28e: 00001001
 L_0xa294:
@@ -8001,7 +8001,7 @@ LoadBackground(0x0); // 0xa2aa: 00001069
 OP_0x65(); // 0xa2b0: 00000065
 OP_0x29(); // 0xa2b4: 00000029
 CleanTextRecord(); // 0xa2b8: 00000025
-ShowText((3620)"With my eyes closed I prayed hard, and wished for that. And then the girl came. The low sound of a motor... And a chime announce her arrival. The doors slowly open and close. After stepping off the elevator the girl walked over to me and stood there."); // 0xa2bc: 0000100c
+ShowText((3620)"With my eyes closed I prayed hard, and wished for that. And then the girl came. The low sound of a motor... And a chime announces her arrival. The doors slowly open and close. After stepping off the elevator the girl walked over to me and stood there."); // 0xa2bc: 0000100c
 HandleInput(); // 0xa2c2: 00000010
 ShowText((3621)"I was able to tell who the girl was without even raising my head."); // 0xa2c6: 0000100c
 HandleInput(); // 0xa2cc: 00000010
@@ -8011,7 +8011,7 @@ OP_0x65(); // 0xa2da: 00000065
 PlayMusic(0x74); // 0xa2de: 0000106c
 ShowText((3622)"¥"Daddy...¥""); // 0xa2e4: 0000100c
 HandleInput(); // 0xa2ea: 00000010
-ShowText((3623)"I could not hold back my overflowing tears. I placed my palms on my face and cried out. Cheryl...why... Why are you doing this... My unintelligible voice resonated with the walls of the hall."); // 0xa2ee: 0000100c
+ShowText((3623)"I could not hold back my overflowing tears. I placed my palms on my face and cried out. ¥"Cheryl... Why... Why are you doing this...?¥" My unintelligible voice resonated with the walls of the hall."); // 0xa2ee: 0000100c
 HandleInput(); // 0xa2f4: 00000010
 CleanScreen(); // 0xa2f8: 00000064
 LoadBackground(0x97); // 0xa2fc: 00001069
@@ -8026,7 +8026,7 @@ CleanScreen(); // 0xa324: 00000064
 LoadBackground(0x97); // 0xa328: 00001069
 OP_0x65(); // 0xa32e: 00000065
 PlayMusic(0x74, 0x1); // 0xa332: 0000206c
-Choice((450)"I said.", (451)"A ) ¥"If you are going to kill me then do it...¥"", (452)"B ) ¥"Give me that handgun...!¥""); // 0xa33a: 00003011
+Choice((450)"I said:", (451)"A ) ¥"If you are going to kill me, then do it...¥"", (452)"B ) ¥"Give me that handgun...!¥""); // 0xa33a: 00003011
 Branch4(0x7f2, L_0xa350); // 0xa344: 00001004
 Jump(L_0xa364); // 0xa34a: 00001001
 L_0xa350:
@@ -8042,7 +8042,7 @@ CleanScreen(); // 0xa372: 00000064
 LoadBackground(0x97); // 0xa376: 00001069
 OP_0x65(); // 0xa37c: 00000065
 PlayMusic(0x74, 0x1); // 0xa380: 0000206c
-ShowText((3625)"¥"Sorry... You daddy doesn't understand, but... If you are going to kill me then do it... I am in agony... To finally be reunited with you...with you like this...¥""); // 0xa388: 0000100c
+ShowText((3625)"¥"Sorry... You daddy doesn't understand, but... If you are going to kill me then do it... I am in agony... To finally be reunited with you... with you like this...¥""); // 0xa388: 0000100c
 HandleInput(); // 0xa38e: 00000010
 ShowText((3626)"With an expressionless face Cheryl points the barrel of the gun at me."); // 0xa392: 0000100c
 HandleInput(); // 0xa398: 00000010
@@ -8058,9 +8058,9 @@ OP_0x65(); // 0xa3c4: 00000065
 PlayMusic(0x74, 0x1); // 0xa3c8: 0000206c
 ShowText((3628)"¥"Dahlia...¥" Dahlia did not move. She looked down on me and began to speak. ¥"...It's terrible. The gods have passed judgment on you... Under the pretext of searching for your missing daughter you were unable to get her back.¥""); // 0xa3d0: 0000100c
 HandleInput(); // 0xa3d6: 00000010
-ShowText((3629)"What...what are you saying... Dahlia taps Cheryl's shoulder and Cheryl holds out the handgun. ¥"Daddy, isn't this yours? It was dropped here.¥" I remained seated, and then I reached out and took the handgun without knowing why."); // 0xa3da: 0000100c
+ShowText((3629)"What... What are you saying...? Dahlia taps Cheryl's shoulder and Cheryl holds out the handgun. ¥"Daddy, isn't this yours? It was dropped here.¥" I remained seated, and then I reached out and took the handgun without knowing why."); // 0xa3da: 0000100c
 HandleInput(); // 0xa3e0: 00000010
-ShowText((3630)"¥"My...handgun?¥" I hurriedly checked my pockets. The handgun was definitely missing. ¥"It doesn't appear that you have realized it yet.¥" I carefully studied the gun I was holding. This is definitely the gun I received from Cybil."); // 0xa3e4: 0000100c
+ShowText((3630)"¥"My... handgun?¥" I hurriedly checked my pockets. The handgun was definitely missing. ¥"It doesn't appear that you have realized it yet.¥" I carefully studied the gun I was holding. This is definitely the gun I received from Cybil."); // 0xa3e4: 0000100c
 HandleInput(); // 0xa3ea: 00000010
 ShowText((3631)"One round is chambered in the gun."); // 0xa3ee: 0000100c
 HandleInput(); // 0xa3f4: 00000010
@@ -8076,21 +8076,21 @@ CleanScreen(); // 0xa420: 00000064
 LoadBackground(0xa3); // 0xa424: 00001069
 OP_0x65(); // 0xa42a: 00000065
 PlayMusic(0x74, 0x1); // 0xa42e: 0000206c
-ShowText((3634)"This is...the antique shop... Cybil heads to the altar at the end of the passage... I follow her... Without making any footstep sounds..."); // 0xa436: 0000100c
+ShowText((3634)"This is... The antique shop... Cybil heads to the altar at the end of the passage... I follow her... Without making any footstep sounds..."); // 0xa436: 0000100c
 HandleInput(); // 0xa43c: 00000010
 ShowText((3635)"Cybil doesn't notice me... I strangle her from behind... I push her down to the floor... I press the gun I am holding to the base of her neck... And forcefully pull the trigger..."); // 0xa440: 0000100c
 HandleInput(); // 0xa446: 00000010
 CleanScreen(); // 0xa44a: 00000064
 LoadBackground(0x7f); // 0xa44e: 00001069
 OP_0x65(); // 0xa454: 00000065
-ShowText((3636)".........Where is this............... ...Hospital...? I leave the examination room... Yes, to get the oil heater... No...instead... I return to the room... Lisa was surprised... I grab her long blond hair... Her scream and the gun shot occur at the same time..."); // 0xa458: 0000100c
+ShowText((3636)".........Where is this............... ...Hospital...? I leave the examination room... Yes, to get the oil heater... No... Instead... I return to the room... Lisa was surprised... I grab her long blond hair... Her scream and the gun shot occur at the same time..."); // 0xa458: 0000100c
 HandleInput(); // 0xa45e: 00000010
 ShowText((3637)"A terrible headache... I cannot take it and run out into the corridor... I run into a man that was surprised by the gun shot and has come out of a room... He sees what I have in my right hand... He sees the red stain on my clothes......."); // 0xa462: 0000100c
 HandleInput(); // 0xa468: 00000010
 CleanScreen(); // 0xa46c: 00000064
 LoadBackground(0x80); // 0xa470: 00001069
 OP_0x65(); // 0xa476: 00000065
-ShowText((3638)"I persistently chase him... I look at his back as he runs away... He is a fool...that Kaufmann... There is a dead end ahead... You have no where left to run to..."); // 0xa47a: 0000100c
+ShowText((3638)"I persistently chase him... I look at his back as he runs away... He is a fool... that Kaufmann... There is a dead end ahead... You have nowhere left to run..."); // 0xa47a: 0000100c
 HandleInput(); // 0xa480: 00000010
 ShowText((3639)"He sank to the floor in the corner of the hall... What a pathetic end... I place my right leg on his shoulder..."); // 0xa484: 0000100c
 HandleInput(); // 0xa48a: 00000010
@@ -8104,13 +8104,13 @@ OP_0x29(); // 0xa4ac: 00000029
 CleanScreen(); // 0xa4b0: 00000064
 LoadBackground(0x99); // 0xa4b4: 00001069
 OP_0x65(); // 0xa4ba: 00000065
-ShowText((3641)"¥"It looks like you have remembered.¥" Dahlia's piercing voice penetrates my eardrums. Something snaps within me. ¥"Dahlia...I...¥" I cannot speak through my tears. Cheryl clings to Dahlia, and stares fixedly at me. She appears to be frightened."); // 0xa4be: 0000100c
+ShowText((3641)"¥"It looks like you have remembered.¥" Dahlia's piercing voice penetrates my eardrums. Something snaps within me. ¥"Dahlia... I...¥" I cannot speak through my tears. Cheryl clings to Dahlia, and stares fixedly at me. She appears to be frightened."); // 0xa4be: 0000100c
 HandleInput(); // 0xa4c4: 00000010
 ShowText((3642)"Silence... It's strange. That my daughter would cling to a woman that she has just met."); // 0xa4c8: 0000100c
 HandleInput(); // 0xa4ce: 00000010
 ShowText((3643)"Even as I shared the same time and space with them, they felt completely like people from another dimension."); // 0xa4d2: 0000100c
 HandleInput(); // 0xa4d8: 00000010
-ShowText((3644)"¥"If your going to kill...then you should do it... No one is left in this town. This town is dead.¥" (Dahlia)"); // 0xa4dc: 0000100c
+ShowText((3644)"¥"If you are going to kill... then you should do it... No one is left in this town. This town is dead.¥""); // 0xa4dc: 0000100c
 HandleInput(); // 0xa4e2: 00000010
 Jump(L_0xa4ec); // 0xa4e6: 00001001
 L_0xa4ec:
@@ -8138,7 +8138,7 @@ LoadEffect(0x0, 0x0, 0x0); // 0xa558: 0000306d
 OP_0x65(); // 0xa562: 00000065
 ShowText((3649)"Cheryl has watered the dandelions that have bloomed in the garden."); // 0xa566: 0000100c
 HandleInput(); // 0xa56c: 00000010
-ShowText((3650)"My body is... In my distant consciousness my entire body trembles."); // 0xa570: 0000100c
+ShowText((3650)"My body is... In my distant consciousness, my entire body trembles."); // 0xa570: 0000100c
 HandleInput(); // 0xa576: 00000010
 ShowText((3651)"I am holding a gun in my right hand, lying face down on the desk in my study. I will never move ever again."); // 0xa57a: 0000100c
 HandleInput(); // 0xa580: 00000010
@@ -8167,7 +8167,7 @@ CleanScreen(); // 0xa5ee: 00000064
 LoadBackground(0x0); // 0xa5f2: 00001069
 OP_0x65(); // 0xa5f8: 00000065
 PlaySecondSoundFx(0x9); // 0xa5fc: 00001073
-ShowText((4216)"I head back to the passage that I just came through. ¥"Dam...Dammit...!¥" My flashlight won't turn on. It seems to be broken."); // 0xa602: 0000100c
+ShowText((4216)"I head back to the passage that I just came through. ¥"Dam-Dammit...!¥" My flashlight won't turn on. It seems to be broken."); // 0xa602: 0000100c
 HandleInput(); // 0xa608: 00000010
 ShowText((4217)"I continue to run through the darkness. There is no source of light in front of or behind me to tell me which way I am going."); // 0xa60c: 0000100c
 HandleInput(); // 0xa612: 00000010
@@ -8185,7 +8185,7 @@ CleanScreen(); // 0xa648: 00000064
 LoadBackground(0x7f); // 0xa64c: 00001069
 OP_0x65(); // 0xa652: 00000065
 PlaySecondSoundFx(0x6); // 0xa656: 00001073
-ShowText((4221)"I search the area around the corpse. ¥".........!¥" There I found a familiar handgun. ¥"This is...the gun that I received from Cybil...¥""); // 0xa65c: 0000100c
+ShowText((4221)"I search the area around the corpse. ¥"...!¥" There I found a familiar handgun. ¥"This is... the gun that I received from Cybil...¥""); // 0xa65c: 0000100c
 HandleInput(); // 0xa662: 00000010
 CleanScreen(); // 0xa666: 00000064
 LoadBackground(0x7f); // 0xa66a: 00001069
@@ -8223,14 +8223,14 @@ ShowText((4230)"¥"Cheryl...! Give me that handgun!¥" I try to take the handgun
 HandleInput(); // 0xa70e: 00000010
 ShowText((4231)"It can't be... It can't be, this handgun is..."); // 0xa712: 0000100c
 HandleInput(); // 0xa718: 00000010
-ShowText((4232)"Cheryl grinned and then placed the barrel of the gun against my forehead. ¥"Goodbye¥" The voice of the girl rocks my eardrums."); // 0xa71c: 0000100c
+ShowText((4232)"Cheryl grinned and then placed the barrel of the gun against my forehead. ¥"Goodbye.¥" The voice of the girl rocks my eardrums."); // 0xa71c: 0000100c
 HandleInput(); // 0xa722: 00000010
 OP_0x29(); // 0xa726: 00000029
 PlaySecondSoundFx(0xf); // 0xa72a: 00001073
 CleanScreen(); // 0xa730: 00000064
 LoadBackground(0x0); // 0xa734: 00001069
 OP_0x65(); // 0xa73a: 00000065
-ShowText((4233)"Bang! The sound of gunfire. With my eyes closed, I waited for my consciousness to fade away. However...something is not right."); // 0xa73e: 0000100c
+ShowText((4233)"Bang! The sound of gunfire. With my eyes closed, I waited for my consciousness to fade away. However... something is not right."); // 0xa73e: 0000100c
 HandleInput(); // 0xa744: 00000010
 ShowText((4234)"I gingerly opened my eyes and saw Cheryl lying in front of me. Cybil was standing behind her, with the gun in her hand pointed at Cheryl."); // 0xa748: 0000100c
 HandleInput(); // 0xa74e: 00000010
@@ -8255,7 +8255,7 @@ OP_0x65(); // 0xa7a6: 00000065
 PlayMusic(0x67); // 0xa7aa: 0000106c
 ShowText((4241)"(That wasn't what we discussed...) (Dahlia)"); // 0xa7b0: 0000100c
 HandleInput(); // 0xa7b6: 00000010
-ShowText((4242)"(Heh... It's not like we ever had a deal in the first place. I will take the white claudia. Because I don't care for trusting you with it.) (Kaufmann)"); // 0xa7ba: 0000100c
+ShowText((4242)"(Heh... It's not like we ever had a deal in the first place. I will take the White Claudia. Because I don't care for trusting you with it.) (Kaufmann)"); // 0xa7ba: 0000100c
 HandleInput(); // 0xa7c0: 00000010
 ShowText((4243)"(Kaufmann... With this you are going to become very rich... I have a good route for distribution...) (Dahlia)"); // 0xa7c4: 0000100c
 HandleInput(); // 0xa7ca: 00000010
@@ -8265,7 +8265,7 @@ ShowText((4245)"(No one is conspiring against you. Since the beginning everythin
 HandleInput(); // 0xa7de: 00000010
 ShowText((4246)"(There is a record in which my share is clearly recorded...) (Dahlia)"); // 0xa7e2: 0000100c
 HandleInput(); // 0xa7e8: 00000010
-ShowText((4247)"(Ha Ha Ha! That piece of paper is now ash. Just like your daughter.) (Lisa)"); // 0xa7ec: 0000100c
+ShowText((4247)"(Ha ha ha! That piece of paper is now ash. Just like your daughter.) (Lisa)"); // 0xa7ec: 0000100c
 HandleInput(); // 0xa7f2: 00000010
 PlaySecondSoundFx(0xf); // 0xa7f6: 00001073
 ShowText((4248)"....................."); // 0xa7fc: 0000100c
@@ -8278,13 +8278,13 @@ ShowText((4249)"¥"Then a gun shot rang out... and a woman's scream reverberated
 HandleInput(); // 0xa822: 00000010
 ShowText((4250)"I was hiding behind a pillar. Dahlia came out of the room alone. She didn't notice me. She was holding a handgun, and her clothes were soaked in blood."); // 0xa826: 0000100c
 HandleInput(); // 0xa82c: 00000010
-ShowText((4251)"I tailed her without her noticing me to this hospital. Once she found you she pulled out her gun once more and pointed it at you."); // 0xa830: 0000100c
+ShowText((4251)"I tailed her without her noticing me to this hospital. Once she found you, she pulled out her gun once more and pointed it at you."); // 0xa830: 0000100c
 HandleInput(); // 0xa836: 00000010
 ShowText((4252)"To protect you I pulled the trigger on the gun I was carrying...¥""); // 0xa83a: 0000100c
 HandleInput(); // 0xa840: 00000010
 ShowText((4253)"In the dark hospital only Cybil's voice echoed on and on. All the people in this world had become corpses, and only outsiders remained."); // 0xa844: 0000100c
 HandleInput(); // 0xa84a: 00000010
-ShowText((4254)"No...wait. One person still remains. Just one..."); // 0xa84e: 0000100c
+ShowText((4254)"No... Wait. One person still remains. Just one..."); // 0xa84e: 0000100c
 HandleInput(); // 0xa854: 00000010
 ShowText((4255)"¥"I have Cheryl somewhere safe. Well then, let's go to her. She can hardly wait to see her father.¥" Cheryl... No, not her. There is still one other person in this world."); // 0xa858: 0000100c
 HandleInput(); // 0xa85e: 00000010
@@ -8300,9 +8300,9 @@ ShowText((4258)"I began to walk behind Cybil. A reunion with Cheryl. I risked my
 HandleInput(); // 0xa890: 00000010
 ShowText((4259)"Cybil's figure sways up and down as I follow her, and my entire body trembles with extreme exhaustion."); // 0xa894: 0000100c
 HandleInput(); // 0xa89a: 00000010
-ShowText((4260)"Just where does Cybil have my daughter? I think that maybe we are walking without no destination."); // 0xa89e: 0000100c
+ShowText((4260)"Just where does Cybil have my daughter? I think that maybe we are walking without destination."); // 0xa89e: 0000100c
 HandleInput(); // 0xa8a4: 00000010
-ShowText((4261)"At that moment I was then...unable to see what Cybil was really up to..."); // 0xa8a8: 0000100c
+ShowText((4261)"At that moment I was then... unable to see what Cybil was really up to..."); // 0xa8a8: 0000100c
 HandleInput(); // 0xa8ae: 00000010
 PlayCredits(); // 0xa8b2: 0000005f
 OP_0x2c(0x3, 0x3); // 0xa8b6: 0000202c
@@ -8423,7 +8423,7 @@ HandleInput(); // 0xab30: 00000010
 LoadSecondEffect(0x2b, 0x3, 0x1); // 0xab34: 0000306e
 LoadSecondEffect(0x0, 0x0, 0x1); // 0xab3e: 0000306e
 LoadSecondEffect(0x0, 0x0, 0x2); // 0xab48: 0000306e
-ShowText((2043)"Wait... What about Cheryl... Just where is she... give me back my daughter... my daughter... Cheryl..."); // 0xab52: 0000100c
+ShowText((2043)"Wait... What about Cheryl...? Just where is she...? Give me back my daughter... my daughter... Cheryl..."); // 0xab52: 0000100c
 HandleInput(); // 0xab58: 00000010
 Jump(L_0xab62); // 0xab5c: 00001001
 L_0xab62:
@@ -8480,7 +8480,7 @@ ShowText((1032)"I then notice that I have come to an alley surrounded by buildin
 HandleInput(); // 0xac48: 00000010
 ShowText((1026)"I begin to run. Only the sounds of my footsteps echo in the surroundings. Just where in the world has Cheryl gone? Did someone lead her away? Various concerns run through my mind."); // 0xac4c: 0000100c
 HandleInput(); // 0xac52: 00000010
-ShowText((1027)"(Ta ta ta ta...) (Onomatopoeia for footsteps) I suddenly get the feeling that I heard footsteps other than my own, so I stop moving right away to check it out."); // 0xac56: 0000100c
+ShowText((1027)"(Tap, tap, tap, tap...) I suddenly get the feeling that I heard footsteps other than my own, so I stop moving right away to check it out."); // 0xac56: 0000100c
 HandleInput(); // 0xac5c: 00000010
 L_0xac60:
 OP_0xe(0xb); // 0xac60: 0000100e
@@ -8543,7 +8543,7 @@ CleanScreen(); // 0xad9c: 00000064
 LoadBackground(0x169); // 0xada0: 00001069
 LoadEffect(0x44, 0x1); // 0xada6: 0000206d
 OP_0x65(); // 0xadae: 00000065
-ShowText((1027)"(Ta ta ta ta...) (Onomatopoeia for footsteps) I suddenly get the feeling that I heard footsteps other than my own, so I stop moving right away to check it out."); // 0xadb2: 0000100c
+ShowText((1027)"(Tap, tap, tap, tap...) I suddenly get the feeling that I heard footsteps other than my own, so I stop moving right away to check it out."); // 0xadb2: 0000100c
 HandleInput(); // 0xadb8: 00000010
 CleanScreen(); // 0xadbc: 00000064
 LoadBackground(0x107); // 0xadc0: 00001069
@@ -8564,14 +8564,14 @@ CleanScreen(); // 0xae14: 00000064
 LoadBackground(0x169); // 0xae18: 00001069
 LoadEffect(0x45, 0x1); // 0xae1e: 0000206d
 OP_0x65(); // 0xae26: 00000065
-ShowText((1027)"(Ta ta ta ta...) (Onomatopoeia for footsteps) I suddenly get the feeling that I heard footsteps other than my own, so I stop moving right away to check it out."); // 0xae2a: 0000100c
+ShowText((1027)"(Tap, tap, tap, tap...) I suddenly get the feeling that I heard footsteps other than my own, so I stop moving right away to check it out."); // 0xae2a: 0000100c
 HandleInput(); // 0xae30: 00000010
 LoadSecondEffect(0x50, 0x1, 0x1); // 0xae34: 0000306e
 ShowText((1032)"I then notice that I have come to an alley surrounded by buildings."); // 0xae3e: 0000100c
 HandleInput(); // 0xae44: 00000010
 ShowText((1026)"I begin to run. Only the sounds of my footsteps echo in the surroundings. Just where in the world has Cheryl gone? Did someone lead her away? Various concerns run through my mind."); // 0xae48: 0000100c
 HandleInput(); // 0xae4e: 00000010
-ShowText((1027)"(Ta ta ta ta...) (Onomatopoeia for footsteps) I suddenly get the feeling that I heard footsteps other than my own, so I stop moving right away to check it out."); // 0xae52: 0000100c
+ShowText((1027)"(Tap, tap, tap, tap...) I suddenly get the feeling that I heard footsteps other than my own, so I stop moving right away to check it out."); // 0xae52: 0000100c
 HandleInput(); // 0xae58: 00000010
 CleanScreen(); // 0xae5c: 00000064
 LoadBackground(0xf0); // 0xae60: 00001069
@@ -8680,7 +8680,7 @@ HandleInput(); // 0xb0c4: 00000010
 LoadSecondEffect(0x41, 0x2, 0x1); // 0xb0c8: 0000306e
 ShowText((1026)"I begin to run. Only the sounds of my footsteps echo in the surroundings. Just where in the world has Cheryl gone? Did someone lead her away? Various concerns run through my mind."); // 0xb0d2: 0000100c
 HandleInput(); // 0xb0d8: 00000010
-ShowText((1027)"(Ta ta ta ta...) (Onomatopoeia for footsteps) I suddenly get the feeling that I heard footsteps other than my own, so I stop moving right away to check it out."); // 0xb0dc: 0000100c
+ShowText((1027)"(Tap, tap, tap, tap...) I suddenly get the feeling that I heard footsteps other than my own, so I stop moving right away to check it out."); // 0xb0dc: 0000100c
 HandleInput(); // 0xb0e2: 00000010
 CleanScreen(); // 0xb0e6: 00000064
 LoadBackground(0xf1); // 0xb0ea: 00001069
@@ -8774,7 +8774,7 @@ ShowText((1032)"I then notice that I have come to an alley surrounded by buildin
 HandleInput(); // 0xb2c6: 00000010
 ShowText((1026)"I begin to run. Only the sounds of my footsteps echo in the surroundings. Just where in the world has Cheryl gone? Did someone lead her away? Various concerns run through my mind."); // 0xb2ca: 0000100c
 HandleInput(); // 0xb2d0: 00000010
-ShowText((1027)"(Ta ta ta ta...) (Onomatopoeia for footsteps) I suddenly get the feeling that I heard footsteps other than my own, so I stop moving right away to check it out."); // 0xb2d4: 0000100c
+ShowText((1027)"(Tap, tap, tap, tap...) I suddenly get the feeling that I heard footsteps other than my own, so I stop moving right away to check it out."); // 0xb2d4: 0000100c
 HandleInput(); // 0xb2da: 00000010
 CleanScreen(); // 0xb2de: 00000064
 LoadBackground(0xf1); // 0xb2e2: 00001069
@@ -8798,13 +8798,13 @@ LoadBackground(0xde); // 0xb33a: 00001069
 LoadEffect(0x3, 0x2); // 0xb340: 0000206d
 OP_0x65(); // 0xb348: 00000065
 HandleInput(); // 0xb34c: 00000010
-ShowText((1027)"(Ta ta ta ta...) (Onomatopoeia for footsteps) I suddenly get the feeling that I heard footsteps other than my own, so I stop moving right away to check it out."); // 0xb350: 0000100c
+ShowText((1027)"(Tap, tap, tap, tap...) I suddenly get the feeling that I heard footsteps other than my own, so I stop moving right away to check it out."); // 0xb350: 0000100c
 HandleInput(); // 0xb356: 00000010
 CleanScreen(); // 0xb35a: 00000064
 LoadBackground(0x169); // 0xb35e: 00001069
 LoadEffect(0x44, 0x1); // 0xb364: 0000206d
 OP_0x65(); // 0xb36c: 00000065
-ShowText((1027)"(Ta ta ta ta...) (Onomatopoeia for footsteps) I suddenly get the feeling that I heard footsteps other than my own, so I stop moving right away to check it out."); // 0xb370: 0000100c
+ShowText((1027)"(Tap, tap, tap, tap...) I suddenly get the feeling that I heard footsteps other than my own, so I stop moving right away to check it out."); // 0xb370: 0000100c
 HandleInput(); // 0xb376: 00000010
 CleanScreen(); // 0xb37a: 00000064
 LoadBackground(0x107); // 0xb37e: 00001069
@@ -8825,7 +8825,7 @@ CleanScreen(); // 0xb3d2: 00000064
 LoadBackground(0x169); // 0xb3d6: 00001069
 LoadEffect(0x45, 0x1); // 0xb3dc: 0000206d
 OP_0x65(); // 0xb3e4: 00000065
-ShowText((1027)"(Ta ta ta ta...) (Onomatopoeia for footsteps) I suddenly get the feeling that I heard footsteps other than my own, so I stop moving right away to check it out."); // 0xb3e8: 0000100c
+ShowText((1027)"(Tap, tap, tap, tap...) I suddenly get the feeling that I heard footsteps other than my own, so I stop moving right away to check it out."); // 0xb3e8: 0000100c
 HandleInput(); // 0xb3ee: 00000010
 CleanScreen(); // 0xb3f2: 00000064
 LoadBackground(0x195); // 0xb3f6: 00001069
@@ -8856,7 +8856,7 @@ ShowText((1032)"I then notice that I have come to an alley surrounded by buildin
 HandleInput(); // 0xb480: 00000010
 ShowText((1026)"I begin to run. Only the sounds of my footsteps echo in the surroundings. Just where in the world has Cheryl gone? Did someone lead her away? Various concerns run through my mind."); // 0xb484: 0000100c
 HandleInput(); // 0xb48a: 00000010
-ShowText((1027)"(Ta ta ta ta...) (Onomatopoeia for footsteps) I suddenly get the feeling that I heard footsteps other than my own, so I stop moving right away to check it out."); // 0xb48e: 0000100c
+ShowText((1027)"(Tap, tap, tap, tap...) I suddenly get the feeling that I heard footsteps other than my own, so I stop moving right away to check it out."); // 0xb48e: 0000100c
 HandleInput(); // 0xb494: 00000010
 CleanScreen(); // 0xb498: 00000064
 LoadBackground(0x96); // 0xb49c: 00001069
@@ -9043,7 +9043,7 @@ LoadBackground(0x2f); // 0xb87e: 00001069
 OP_0x65(); // 0xb884: 00000065
 ShowText((1118)"At the end of the alley I see a familiar sketchbook that appears to have been thrown away. The likeness of me that Cheryl drew is on the cover of the sketchbook."); // 0xb888: 0000100c
 HandleInput(); // 0xb88e: 00000010
-ShowText((1119)"¥"This is definitely Cheryl's...¥" (Sketchbook opens)"); // 0xb892: 0000100c
+ShowText((1119)"¥"This is definitely Cheryl's...¥""); // 0xb892: 0000100c
 HandleInput(); // 0xb898: 00000010
 LoadSecondEffect(0x1c, 0x1); // 0xb89c: 0000206e
 ShowText((1120)"I try opening it. Inside the following is written in red ink: ¥"to School¥""); // 0xb8a4: 0000100c
@@ -9080,7 +9080,7 @@ CleanScreen(); // 0xb934: 00000064
 LoadBackground(0x40, 0x2); // 0xb938: 00002069
 OP_0x65(); // 0xb940: 00000065
 LoadSecondEffect(0x1e, 0x1); // 0xb944: 0000206e
-ShowText((1207)"In the center the fires of hell burned, and everything made it look like this room was meant for prayer. And then it...was there. It slowly moved around the enormous sconce from which flames and ash rose."); // 0xb94c: 0000100c
+ShowText((1207)"In the center the fires of hell burned, and everything made it look like this room was meant for prayer. And then it... was there. It slowly moved around the enormous sconce from which flames and ash rose."); // 0xb94c: 0000100c
 HandleInput(); // 0xb952: 00000010
 ShowText((1208)"The lizard looks to have suddenly mutated. Its outer shell is a mucous membrane type. It just stares at me, and with surprisingly comfortable speed, it looks for a chance to attack."); // 0xb956: 0000100c
 HandleInput(); // 0xb95c: 00000010
@@ -9107,7 +9107,7 @@ L_0xb9b2:
 CleanScreen(); // 0xb9b2: 00000064
 LoadEffect(0x1f, 0x1, 0x1); // 0xb9b6: 0000306d
 OP_0x65(); // 0xb9c0: 00000065
-ShowText((1207)"In the center the fires of hell burned, and everything made it look like this room was meant for prayer. And then it...was there. It slowly moved around the enormous sconce from which flames and ash rose."); // 0xb9c4: 0000100c
+ShowText((1207)"In the center the fires of hell burned, and everything made it look like this room was meant for prayer. And then it... was there. It slowly moved around the enormous sconce from which flames and ash rose."); // 0xb9c4: 0000100c
 HandleInput(); // 0xb9ca: 00000010
 LoadSecondEffect(0x1f, 0x1, 0x1, 0x1); // 0xb9ce: 0000406e
 ShowText((1208)"The lizard looks to have suddenly mutated. Its outer shell is a mucous membrane type. It just stares at me, and with surprisingly comfortable speed, it looks for a chance to attack."); // 0xb9da: 0000100c
@@ -9138,7 +9138,7 @@ L_0xba58:
 OP_0xe(0x7a); // 0xba58: 0000100e
 ShowText((1439)"I made my way into the room at the end of the passage. It is small, and the smell of something having been burned is in the air. Once I saw an altar appear in the darkness I realized that this is the ¥"church¥" that Dahlia was talking about."); // 0xba5e: 0000100c
 HandleInput(); // 0xba64: 00000010
-ShowText((1440)"I look around the area. An axe have been displayed on the wall. But nothing else stands out. While shaking my head I decide to try going back through the passage I came from. And at that moment...a light bright enough to make me look away emanates from the altar."); // 0xba68: 0000100c
+ShowText((1440)"I look around the area. An axe is being displayed on the wall. But nothing else stands out. While shaking my head I decide to try going back through the passage I came from. And at that moment... a light bright enough to make me look away emanates from the altar."); // 0xba68: 0000100c
 HandleInput(); // 0xba6e: 00000010
 OP_0x1b(0x14); // 0xba72: 0000101b
 ShowText((1441)"I think I heard the sound of a giant match being stuck, and then two enormous pillars of flame rose from the altar, as if a ritual were beginning or something. Even at the distance I am at I can feel the heat from those flames."); // 0xba78: 0000100c
@@ -9175,7 +9175,7 @@ Nop7(); // 0xbb08: 00000007
 Jump(L_0xc0f4); // 0xbb0c: 00001001
 L_0xbb12:
 OP_0x1b(0x18); // 0xbb12: 0000101b
-ShowText((1505)"¥"What...what is this...?¥" A giant moth... I guess I didn't completely kill it. That caterpillar that I shot at the Town Center has followed me here."); // 0xbb18: 0000100c
+ShowText((1505)"¥"What... What is this...?¥" A giant moth... I guess I didn't completely kill it. That caterpillar that I shot at the Town Center has followed me here."); // 0xbb18: 0000100c
 HandleInput(); // 0xbb1e: 00000010
 ShowText((1506)"And it has matured. It dances against the black sky and is looking down on me. In addition to the poison that it can discharge from its mouth, it now has a stinger with which to stick me with."); // 0xbb22: 0000100c
 HandleInput(); // 0xbb28: 00000010
@@ -9186,17 +9186,17 @@ CleanScreen(); // 0xbb38: 00000064
 LoadEffect(0x2d, 0x1, 0x1); // 0xbb3c: 0000306d
 PlayMusic(0x72); // 0xbb46: 0000106c
 OP_0x65(); // 0xbb4c: 00000065
-ShowText((1751)"¥"Cheryl!! Wait......¥""); // 0xbb50: 0000100c
+ShowText((1751)"¥"Cheryl!! Wait...¥""); // 0xbb50: 0000100c
 HandleInput(); // 0xbb56: 00000010
 PlaySecondSoundFx(0x2f); // 0xbb5a: 00001073
 LoadSecondEffect(0x2d, 0x2, 0x2); // 0xbb60: 0000306e
 LoadSecondEffect(0x0, 0x0, 0x2); // 0xbb6a: 0000306e
-ShowText((1752)"Then electricity overflowed from the entire body of the creature that was born from Alessa. It divided into several lighting bolts, which struck above my head."); // 0xbb74: 0000100c
+ShowText((1752)"Then electricity overflowed from the entire body of the creature that was born from Alessa. It divided into several lightning bolts, which struck above my head."); // 0xbb74: 0000100c
 HandleInput(); // 0xbb7a: 00000010
 PlaySecondSoundFx(0x2f); // 0xbb7e: 00001073
 LoadSecondEffect(0x2d, 0x2, 0x2); // 0xbb84: 0000306e
 LoadSecondEffect(0x0, 0x0, 0x2); // 0xbb8e: 0000306e
-ShowText((1756)"I ready my weapon. During the short time between the lighting strikes I fire many bullets into the creature's body."); // 0xbb98: 0000100c
+ShowText((1756)"I ready my weapon. During the short time between the lightning strikes I fire many bullets into the creature's body."); // 0xbb98: 0000100c
 HandleInput(); // 0xbb9e: 00000010
 PlaySecondSoundFx(0xf); // 0xbba2: 00001073
 LoadSecondEffect(0xf, 0x1, 0x2); // 0xbba8: 0000306e
@@ -9308,7 +9308,7 @@ L_0xbde2:
 OP_0xe(0xa8); // 0xbde2: 0000100e
 ShowText((2537)"The mark of Samael... I recall that that is what Dahlia called it. And then my body trembled... ¥"Alessa... Is Alessa here? In this area...¥" What did you just say..."); // 0xbde8: 0000100c
 HandleInput(); // 0xbdee: 00000010
-ShowText((2538)"¥"Eh¥" For an instant we looked each other in the faint light that was lighting the darkness. ¥"What...what did you just say?¥" ¥"I said, Is Alessa here?¥" Lisa's face suddenly twisted in anger."); // 0xbdf2: 0000100c
+ShowText((2538)"¥"Huh?¥" For an instant we looked each other in the faint light that was lighting the darkness. ¥"What... What did you just say?¥" ¥"I said, Is Alessa here?¥" Lisa's face suddenly twisted in anger."); // 0xbdf2: 0000100c
 OP_0x1b(0x2d); // 0xbdf8: 0000101b
 HandleInput(); // 0xbdfe: 00000010
 Jump(L_0xc0f4); // 0xbe02: 00001001


### PR DESCRIPTION
First revision pass at Harry's script in English. Highlights:
 - Metatron's spelling was corrected.
 - Removed a lot of extra periods on ellipsis. The largest ones that imply a full silence or distorsion from a telephone line were spared.
 - Added missing quote marks at a couple of Lisa's dialogues.
 - Added single quotation marks for quotes within a quote.
 - Corrected some onomatopoeias that had an extra translator's note.
 - Corrected the word "gunpowder", which was mispelled every single time.
 - Corrected all instances of the word "ok" in lowercase, which should be spelled "okay" or "okey".
 - Removed what seems to be leftovers from other files. A special case is some dialogue that starts with the number 5001.
 - Replaced "pet bottle" with "plastic bottle", following the game's official translation.
 - Changed the puzzle tutorial's button names to follow N's official naming conventions.
 - Other corrections.